### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   all-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nshiab/simple-data-analysis/security/code-scanning/2](https://github.com/nshiab/simple-data-analysis/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to restrict the permissions of the `GITHUB_TOKEN` to `contents: read`. This is the minimal permission required for the workflow to function correctly, as it only needs to read the repository contents to run the tests. No job-specific permissions are necessary since the workflow does not perform any write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
