### PR TITLE
Add normalizeString method

### DIFF
--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -114,6 +114,7 @@ import hybridSearch from "../methods/hybridSearch.ts";
 import createFtsIndex from "../methods/createFtsIndex.ts";
 import createVssIndex from "../methods/createVssIndex.ts";
 import bm25 from "../methods/bm25.ts";
+import normalizeString from "../methods/normalizeString.ts";
 
 /**
  * Represents a table within a SimpleDB database, capable of handling tabular, geospatial, and vector data.
@@ -5452,6 +5453,59 @@ export default class SimpleTable extends Simple {
    */
   async getColumns(): Promise<string[]> {
     return await getColumns(this);
+  }
+
+  /**
+   * Normalizes string values in a column by:
+   * 1. Decomposing Unicode accents (NFD) and removing combining marks
+   * 2. Optionally stripping punctuation (default: true)
+   * 3. Converting to lowercase
+   * 4. Normalizing whitespace (multiple spaces/tabs/newlines → single space)
+   * 5. Trimming leading/trailing whitespace
+   *
+   * Produces nearly identical output to `journalism-format`'s `normalizeString()` function for all common cases including accented Latin characters (ÉÑÜéñü). Edge cases with decorative punctuation like ¡¿ may differ.
+   *
+   * This method uses DuckDB's native `strip_accents()` function for efficient accent removal, making it much faster than JavaScript-based alternatives. It works on the server side without requiring JavaScript UDFs.
+   *
+   * @param sourceColumn The column containing the text to normalize
+   * @param targetColumn The column to store the normalized results
+   * @param options Configuration options
+   * @param options.stripPunctuation Strip punctuation and underscores (default: true)
+   *
+   * @returns The same SimpleTable instance for chaining
+   *
+   * @example
+   * ```ts
+   * // Normalize text column and store in new column
+   * await table.normalizeString("Recipe", "recipe_normalized");
+   * // "Épicerie Parisienne!" → "epicerie parisienne"
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Keep punctuation (useful for emails, URLs)
+   * await table.normalizeString("text", "text_normalized", { stripPunctuation: false });
+   * // "Hello, World!" → "hello, world!"
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Produces same results as journalism-format's normalizeString for core cases
+   * await table.normalizeString("Name", "name_normalized");
+   * // "Évènement!" → "evenement" (same as journalism-format)
+   * // "Café?" → "cafe" (same as journalism-format)
+   * ```
+   *
+   * @recommendation Consider using `normalizeString()` to preprocess text columns before search/AI methods for better matching.
+   *
+   * @category Text Processing
+   */
+  async normalizeString(
+    sourceColumn: string,
+    targetColumn: string,
+    options: { stripPunctuation?: boolean } = {},
+  ): Promise<SimpleTable> {
+    return await normalizeString(this, sourceColumn, targetColumn, options);
   }
 
   /**

--- a/src/methods/normalizeString.ts
+++ b/src/methods/normalizeString.ts
@@ -1,0 +1,93 @@
+import type SimpleTable from "../class/SimpleTable.ts";
+import queryDB from "../helpers/queryDB.ts";
+import mergeOptions from "../helpers/mergeOptions.ts";
+
+/**
+ * Normalizes string values in a column by:
+ * 1. Decomposing Unicode accents (NFD) and removing combining marks
+ * 2. Optionally stripping punctuation (default: true)
+ * 3. Converting to lowercase
+ * 4. Normalizing whitespace (multiple spaces/tabs/newlines → single space)
+ * 5. Trimming leading/trailing whitespace
+ *
+ * Produces nearly identical output to `journalism-format`'s `normalizeString()` function for all common cases including accented Latin characters (ÉÑÜéñü). Edge cases with decorative punctuation like ¡¿ may differ.
+ *
+ * @param simpleTable The SimpleTable instance
+ * @param sourceColumn The column containing the text to normalize
+ * @param targetColumn The column to store the normalized results
+ * @param options Configuration options
+ * @param options.stripPunctuation Strip punctuation and underscores (default: true)
+ *
+ * @returns The same SimpleTable instance for chaining
+ *
+ * @example
+ * ```ts
+ * // Normalize text column and store in new column
+ * await table.normalizeString("Recipe", "recipe_normalized");
+ * // "Épicerie Parisienne!" → "epicerie parisienne"
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Keep punctuation (useful for emails, URLs)
+ * await table.normalizeString("text", "text_normalized", { stripPunctuation: false });
+ * // "Hello, World!" → "hello, world!"
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Produces same results as journalism-format's normalizeString for core cases
+ * await table.normalizeString("Name", "name_normalized");
+ * // "Évènement!" → "evenement" (same as journalism-format)
+ * // "Café?" → "cafe" (same as journalism-format)
+ * ```
+ *
+ * @category Text Processing
+ *
+ * @recommendation Consider using `normalizeString()` to preprocess text columns before search/AI methods for better matching.
+ */
+export default async function normalizeString(
+  simpleTable: SimpleTable,
+  sourceColumn: string,
+  targetColumn: string,
+  options: { stripPunctuation?: boolean } = {},
+): Promise<SimpleTable> {
+  const { stripPunctuation = true } = options;
+
+  // Step 1: Remove accents using DuckDB's native strip_accents() function
+  const accentRemoved = `strip_accents("${sourceColumn}")`;
+
+  // Step 2: Convert to lowercase for consistent comparison
+  const lowercased = `lower(${accentRemoved})`;
+
+  // Step 3: Conditionally remove punctuation using POSIX character class
+  const punctuationRemoved = stripPunctuation
+    ? `regexp_replace(${lowercased}, '[[:punct:]]', '', 'g')`
+    : lowercased;
+
+  // Step 4: Normalize whitespace - trim edges and collapse multiple spaces
+  const normalizedClause =
+    `trim(regexp_replace(${punctuationRemoved}, '\\s+', ' ', 'g'))`;
+
+  await queryDB(
+    simpleTable,
+    `CREATE OR REPLACE TABLE "${simpleTable.name}" AS 
+    SELECT *,
+      CASE 
+        WHEN "${sourceColumn}" IS NULL THEN NULL
+        ELSE ${normalizedClause}
+      END AS "${targetColumn}"
+    FROM "${simpleTable.name}"`,
+    mergeOptions(simpleTable, {
+      table: simpleTable.name,
+      method: "normalizeString()",
+      parameters: {
+        sourceColumn,
+        targetColumn,
+        stripPunctuation,
+      },
+    }),
+  );
+
+  return simpleTable;
+}

--- a/test/unit/methods/normalizeString.test.ts
+++ b/test/unit/methods/normalizeString.test.ts
@@ -1,0 +1,217 @@
+import { assertEquals } from "@std/assert";
+import SimpleDB from "../../../src/class/SimpleDB.ts";
+import normalizeString from "../../../src/methods/normalizeString.ts";
+
+Deno.test("normalizeString - convert to lowercase and strip punctuation", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("test");
+  await table.loadArray([
+    { text: "Hello, World!" },
+    { text: "HELLO" },
+    { text: "hElLo" },
+  ]);
+
+  await normalizeString(table, "text", "normalized");
+
+  const results = await table.getData() as {
+    text: string;
+    normalized: string;
+  }[];
+
+  assertEquals(results[0].normalized, "hello world");
+  assertEquals(results[1].normalized, "hello");
+  assertEquals(results[2].normalized, "hello");
+});
+
+Deno.test("normalizeString - strip punctuation keeps alphanumeric", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("test");
+  await table.loadArray([
+    { text: "100%" },
+    { text: "email@example.com" },
+    { text: "multi-word-string" },
+  ]);
+
+  await normalizeString(table, "text", "normalized");
+
+  const results = await table.getData() as {
+    text: string;
+    normalized: string;
+  }[];
+
+  assertEquals(results[0].normalized, "100");
+  assertEquals(results[1].normalized, "emailexamplecom");
+  assertEquals(results[2].normalized, "multiwordstring");
+});
+
+Deno.test("normalizeString - keep punctuation option", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("test");
+  await table.loadArray([
+    { text: "Hello, World!" },
+    { text: "100%" },
+  ]);
+
+  await normalizeString(table, "text", "normalized", {
+    stripPunctuation: false,
+  });
+
+  const results = await table.getData() as {
+    text: string;
+    normalized: string;
+  }[];
+
+  assertEquals(results[0].normalized, "hello, world!");
+  assertEquals(results[1].normalized, "100%");
+});
+
+Deno.test("normalizeString - trim and normalize whitespace", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("test");
+  await table.loadArray([
+    { text: "  hello  " },
+    { text: "\tworld\n" },
+    { text: "  multiple   spaces  " },
+  ]);
+
+  await normalizeString(table, "text", "normalized");
+
+  const results = await table.getData() as {
+    text: string;
+    normalized: string;
+  }[];
+
+  assertEquals(results[0].normalized, "hello");
+  assertEquals(results[1].normalized, "world");
+  assertEquals(results[2].normalized, "multiple spaces");
+});
+
+Deno.test("normalizeString - NULL handling", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("test");
+  await table.loadArray([
+    { text: "Hello" },
+    { text: null },
+    { text: "World" },
+  ]);
+
+  await normalizeString(table, "text", "normalized");
+
+  const results = await table.getData() as {
+    text: string | null;
+    normalized: string | null;
+  }[];
+
+  assertEquals(results[0].normalized, "hello");
+  assertEquals(results[1].normalized, null);
+  assertEquals(results[2].normalized, "world");
+});
+
+Deno.test("normalizeString - empty and whitespace-only strings", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("test");
+  await table.loadArray([
+    { text: "" },
+    { text: "   " },
+  ]);
+
+  await normalizeString(table, "text", "normalized");
+
+  const results = await table.getData() as {
+    text: string;
+    normalized: string;
+  }[];
+
+  assertEquals(results[0].normalized, "");
+  assertEquals(results[1].normalized, "");
+});
+
+Deno.test("normalizeString - special patterns", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("test");
+  await table.loadArray([
+    { text: "email@example.com" },
+    { text: "price: $99.99" },
+  ]);
+
+  await normalizeString(table, "text", "normalized");
+
+  const results = await table.getData() as {
+    text: string;
+    normalized: string;
+  }[];
+
+  assertEquals(results[0].normalized, "emailexamplecom");
+  assertEquals(results[1].normalized, "price 9999");
+});
+
+Deno.test("normalizeString - mixed string types", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("test");
+  await table.loadArray([
+    { text: "Hello" },
+    { text: "123" },
+    { text: "World" },
+    { text: null },
+  ]);
+
+  await normalizeString(table, "text", "normalized");
+
+  const results = await table.getData() as {
+    text: string | null;
+    normalized: string | null;
+  }[];
+
+  assertEquals(results[0].normalized, "hello");
+  assertEquals(results[1].normalized, "123");
+  assertEquals(results[2].normalized, "world");
+  assertEquals(results[3].normalized, null);
+});
+
+Deno.test("normalizeString - long strings", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("test");
+  const longText = "Hello " + "World ".repeat(10000) + "!";
+  await table.loadArray([{ text: longText }]);
+
+  await normalizeString(table, "text", "normalized");
+
+  const results = await table.getData() as {
+    text: string;
+    normalized: string;
+  }[];
+
+  assertEquals(results[0].normalized.charAt(0), "h");
+  assertEquals(typeof results[0].normalized, "string");
+});
+
+Deno.test("normalizeString - matches journalism-format core tests", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("test");
+  await table.loadArray([
+    { text: "Évènement!", expected: "evenement" },
+    { text: "Café?", expected: "cafe" },
+    { text: "Niño!", expected: "nino" },
+    { text: " façade... ", expected: "facade" },
+    { text: "ÖBB (Austria)", expected: "obb austria" },
+    { text: "", expected: "" },
+    { text: "Hello, World!", expected: "hello world" },
+    { text: "Wait... what?", expected: "wait what" },
+    { text: "100%", expected: "100" },
+    { text: "email@example.com", expected: "emailexamplecom" },
+    { text: "multi-word-string", expected: "multiwordstring" },
+    { text: "underscore_test", expected: "underscoretest" },
+  ]);
+
+  await normalizeString(table, "text", "normalized");
+
+  const results = await table.getData() as {
+    text: string;
+    normalized: string;
+    expected: string;
+  }[];
+
+  for (const row of results) {
+    assertEquals(row.normalized, row.expected);
+  }
+});


### PR DESCRIPTION
Implements normalizeString() method for SimpleDataAnalysis with journalism-format compatibility. Uses DuckDB's native strip_accents() for fast accent removal. Includes comprehensive tests and documentation.