### PR TITLE
Remove Playwright references

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-      - run: deno install --allow-scripts=npm:playwright-chromium && deno publish
+      - run: deno publish

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you want to add the library to an existing project, run this:
 
 ```bash
 # Deno >= 2.2.x
-deno install --node-modules-dir=auto --allow-scripts=npm:playwright-chromium jsr:@nshiab/simple-data-analysis
+deno install --node-modules-dir=auto jsr:@nshiab/simple-data-analysis
 # To run with Deno
 deno run -A main.ts
 

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     ".": "./src/index.ts"
   },
   "tasks": {
-    "all-tests": "deno install --allow-scripts=npm:playwright-chromium && deno fmt --check && deno lint && deno check src/index.ts && deno publish --allow-dirty --dry-run && rm -rf test/output && deno test -A --env-file --fail-fast && deno task llm",
+    "all-tests": "deno fmt --check && deno lint && deno check src/index.ts && deno publish --allow-dirty --dry-run && rm -rf test/output && deno test -A --env-file --fail-fast && deno task llm",
     "llm": "deno doc --json src/index.ts > docs.json && deno run -A src/generateLlmMd.ts && deno fmt llm.md",
     "test-coverage": "deno test -A --env-file --fail-fast --coverage=cov_profile && deno coverage cov_profile",
     "patch-no-tests": "deno run -A src/incrementVersion.ts patch",


### PR DESCRIPTION
Closes #1183. This PR removes leftover Playwright installation commands and documentation now that it is no longer a dependency.