### PR TITLE
Add toDW, loadDW, toGeoDW, and loadGeoDW methods

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -30,7 +30,7 @@
   "nodeModulesDir": "auto",
   "imports": {
     "@nshiab/journalism-ai": "jsr:@nshiab/journalism-ai@^1.2.23",
-    "@nshiab/journalism-dataviz": "jsr:@nshiab/journalism-dataviz@^1.0.16",
+    "@nshiab/journalism-dataviz": "jsr:@nshiab/journalism-dataviz@^1.0.17",
     "@nshiab/journalism-format": "jsr:@nshiab/journalism-format@^1.1.9",
     "@nshiab/journalism-google": "jsr:@nshiab/journalism-google@^1.0.10",
     "@nshiab/simple-data-analysis-core": "jsr:@nshiab/simple-data-analysis-core@^1.0.1",

--- a/deno.lock
+++ b/deno.lock
@@ -2,7 +2,7 @@
   "version": "5",
   "specifiers": {
     "jsr:@nshiab/journalism-ai@^1.2.23": "1.2.23",
-    "jsr:@nshiab/journalism-dataviz@^1.0.16": "1.0.16",
+    "jsr:@nshiab/journalism-dataviz@^1.0.17": "1.0.17",
     "jsr:@nshiab/journalism-format@^1.1.3": "1.1.9",
     "jsr:@nshiab/journalism-format@^1.1.7": "1.1.9",
     "jsr:@nshiab/journalism-format@^1.1.9": "1.1.9",
@@ -36,8 +36,8 @@
         "npm:ollama"
       ]
     },
-    "@nshiab/journalism-dataviz@1.0.16": {
-      "integrity": "a4667f8f8076c0697d1296e6bd4d4db0877af599596ead5dacd68153c4fbfd36",
+    "@nshiab/journalism-dataviz@1.0.17": {
+      "integrity": "c4061e9cca6c938478874af613a524f8a4971653d9adb372e998dfd5fb2001fd",
       "dependencies": [
         "jsr:@nshiab/journalism-format@^1.1.7",
         "npm:@napi-rs/canvas",
@@ -45,6 +45,7 @@
         "npm:@resvg/resvg-js",
         "npm:@types/d3-geo",
         "npm:d3-array",
+        "npm:d3-dsv",
         "npm:d3-geo",
         "npm:linkedom"
       ]
@@ -1284,7 +1285,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@nshiab/journalism-ai@^1.2.23",
-      "jsr:@nshiab/journalism-dataviz@^1.0.16",
+      "jsr:@nshiab/journalism-dataviz@^1.0.17",
       "jsr:@nshiab/journalism-format@^1.1.9",
       "jsr:@nshiab/journalism-google@^1.0.10",
       "jsr:@nshiab/simple-data-analysis-core@^1.0.1",

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -1,11 +1,16 @@
 import { SimpleTable as SimpleTableCore } from "@nshiab/simple-data-analysis-core";
+import { unlinkSync, writeFileSync } from "node:fs";
 import type SimpleDB from "./SimpleDB.ts";
 import {
+  getDataDW,
   logBarChart,
   logDotChart,
   logLineChart,
+  publishChartDW,
   rewind,
   saveChart,
+  updateDataDW,
+  updateNotesDW,
 } from "@nshiab/journalism-dataviz";
 import cleanDatavizGlobals from "../helpers/cleanDatavizGlobals.ts";
 import { getSheetData, overwriteSheetData } from "@nshiab/journalism-google";
@@ -1095,6 +1100,173 @@ export default class SimpleTable extends SimpleTableCore {
     apiKey?: string;
   } = {}): Promise<void> {
     await this.loadArray(await getSheetData(sheetUrl, options));
+  }
+
+  // ===================== DATAWRAPPER METHODS =====================
+
+  /**
+   * Writes the table data as CSV to a Datawrapper chart or table.
+   *
+   * Authentication is handled via an API key stored in the environment variable `DATAWRAPPER_KEY`, or a custom variable name via `options.apiKey`.
+   *
+   * @param chartId - The unique ID of the Datawrapper chart or table to update. This ID can be found in the Datawrapper URL or dashboard.
+   * @param options - An optional object with configuration options:
+   * @param options.apiKey - The name of the environment variable that stores your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to `"DATAWRAPPER_KEY"`.
+   * @param options.note - A string to update the chart's notes field with (e.g., a last-updated timestamp).
+   * @param options.republish - If `true`, republishes the chart after updating the data. Defaults to `false`.
+   * @returns A promise that resolves when the data has been sent to Datawrapper.
+   * @category Exporting Data
+   *
+   * @example
+   * ```ts
+   * // Update a Datawrapper chart with the table data
+   * await table.toDW("myChartId");
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Update data, add a note, and republish
+   * await table.toDW("myChartId", {
+   *   note: `Last updated: ${new Date().toLocaleString()}`,
+   *   republish: true,
+   * });
+   * ```
+   */
+  async toDW(
+    chartId: string,
+    options: {
+      apiKey?: string;
+      note?: string;
+      republish?: boolean;
+    } = {},
+  ): Promise<void> {
+    await updateDataDW(chartId, await this.getDataAsCSV(), {
+      apiKey: options.apiKey,
+    });
+    if (typeof options.note === "string") {
+      await updateNotesDW(chartId, options.note, { apiKey: options.apiKey });
+    }
+    if (options.republish === true) {
+      await publishChartDW(chartId, { apiKey: options.apiKey });
+    }
+  }
+
+  /**
+   * Loads data from a Datawrapper chart or table into the table.
+   *
+   * Authentication is handled via an API key stored in the environment variable `DATAWRAPPER_KEY`, or a custom variable name via `options.apiKey`.
+   *
+   * @param chartId - The unique ID of the Datawrapper chart or table. This ID can be found in the Datawrapper URL or dashboard.
+   * @param options - An optional object with configuration options:
+   * @param options.apiKey - The name of the environment variable that stores your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to `"DATAWRAPPER_KEY"`.
+   * @returns A promise that resolves when the data has been loaded into the table.
+   * @category Loading Data
+   *
+   * @example
+   * ```ts
+   * // Load data from a Datawrapper chart
+   * await table.loadDW("myChartId");
+   * ```
+   */
+  async loadDW(
+    chartId: string,
+    options: {
+      apiKey?: string;
+    } = {},
+  ): Promise<void> {
+    const data = await getDataDW(chartId, {
+      parse: true,
+      apiKey: options.apiKey,
+    });
+    await this.loadArray(data as Record<string, string>[]);
+  }
+
+  /**
+   * Writes the table's geospatial data as GeoJSON to a Datawrapper map.
+   *
+   * Authentication is handled via an API key stored in the environment variable `DATAWRAPPER_KEY`, or a custom variable name via `options.apiKey`.
+   *
+   * @param chartId - The unique ID of the Datawrapper map to update. This ID can be found in the Datawrapper URL or dashboard.
+   * @param options - An optional object with configuration options:
+   * @param options.apiKey - The name of the environment variable that stores your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to `"DATAWRAPPER_KEY"`.
+   * @param options.column - The name of the geometry column to use. If omitted, the method will automatically attempt to find a geometry column.
+   * @param options.note - A string to update the map's notes field with.
+   * @param options.republish - If `true`, republishes the map after updating the data. Defaults to `false`.
+   * @returns A promise that resolves when the data has been sent to Datawrapper.
+   * @category Exporting Data
+   *
+   * @example
+   * ```ts
+   * // Update a Datawrapper map with the table's geo data
+   * await table.toGeoDW("myMapId");
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Update data, add a note, and republish
+   * await table.toGeoDW("myMapId", {
+   *   note: `Last updated: ${new Date().toLocaleString()}`,
+   *   republish: true,
+   * });
+   * ```
+   */
+  async toGeoDW(
+    chartId: string,
+    options: {
+      apiKey?: string;
+      column?: string;
+      note?: string;
+      republish?: boolean;
+    } = {},
+  ): Promise<void> {
+    const geoData = await this.getGeoData(options.column);
+    await updateDataDW(chartId, JSON.stringify(geoData), {
+      apiKey: options.apiKey,
+    });
+    if (typeof options.note === "string") {
+      await updateNotesDW(chartId, options.note, { apiKey: options.apiKey });
+    }
+    if (options.republish === true) {
+      await publishChartDW(chartId, { apiKey: options.apiKey });
+    }
+  }
+
+  /**
+   * Loads geospatial data from a Datawrapper map into the table.
+   *
+   * Authentication is handled via an API key stored in the environment variable `DATAWRAPPER_KEY`, or a custom variable name via `options.apiKey`.
+   *
+   * The data is temporarily written to `.sda-cache/<chartId>.json` and removed after loading. Remember to add `.sda-cache` to your `.gitignore`.
+   *
+   * @param chartId - The unique ID of the Datawrapper map. This ID can be found in the Datawrapper URL or dashboard.
+   * @param options - An optional object with configuration options:
+   * @param options.apiKey - The name of the environment variable that stores your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to `"DATAWRAPPER_KEY"`.
+   * @returns A promise that resolves when the data has been loaded into the table.
+   * @category Loading Data
+   *
+   * @example
+   * ```ts
+   * // Load geo data from a Datawrapper map
+   * await table.loadGeoDW("myMapId");
+   * ```
+   */
+  async loadGeoDW(
+    chartId: string,
+    options: {
+      apiKey?: string;
+    } = {},
+  ): Promise<void> {
+    const jsonString = await getDataDW(chartId, {
+      apiKey: options.apiKey,
+    }) as string;
+    const tempPath = `.sda-cache/${chartId}.json`;
+    try {
+      createDirectory(".sda-cache");
+      writeFileSync(tempPath, jsonString);
+      await this.loadGeoData(tempPath);
+    } finally {
+      unlinkSync(tempPath);
+    }
   }
 
   // ===================== CHARTING METHODS =====================

--- a/test/unit/methods/loadDW.test.ts
+++ b/test/unit/methods/loadDW.test.ts
@@ -1,0 +1,30 @@
+import { assertEquals } from "@std/assert";
+import { SimpleDB } from "../../../src/index.ts";
+
+const apiKey = Deno.env.get("DATAWRAPPER_KEY");
+if (typeof apiKey === "string" && apiKey !== "") {
+  Deno.test("should load data from a Datawrapper chart", {
+    sanitizeResources: false,
+  }, async () => {
+    const sdb = new SimpleDB();
+    const table = sdb.newTable();
+
+    // First write known data to the chart.
+    await table.loadArray([
+      { salary: "75000", hireDate: "2022-12-15" },
+      { salary: "80000", hireDate: "2023-01-20" },
+    ]);
+    await table.toDW("ntURh");
+
+    // Then load it back.
+    const table2 = sdb.newTable();
+    await table2.loadDW("ntURh");
+
+    assertEquals(await table2.getData(), [
+      { salary: "75000", hireDate: "2022-12-15" },
+      { salary: "80000", hireDate: "2023-01-20" },
+    ]);
+  });
+} else {
+  console.log("No DATAWRAPPER_KEY in process.env");
+}

--- a/test/unit/methods/loadGeoDW.test.ts
+++ b/test/unit/methods/loadGeoDW.test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "@std/assert";
+import { SimpleDB } from "../../../src/index.ts";
+
+const apiKey = Deno.env.get("DATAWRAPPER_KEY");
+if (typeof apiKey === "string" && apiKey !== "") {
+  Deno.test("should load geo data from a Datawrapper map", {
+    sanitizeResources: false,
+  }, async () => {
+    const sdb = new SimpleDB();
+    const table = sdb.newTable();
+
+    // First write known geo data to the map.
+    await table.loadGeoData(
+      "test/geodata/files/CanadianProvincesAndTerritories.json",
+    );
+    await table.toGeoDW("lDO6F");
+
+    // Then load it back.
+    const table2 = sdb.newTable();
+    await table2.loadGeoDW("lDO6F");
+
+    const geoData = await table2.getGeoData();
+    assertEquals(geoData.type, "FeatureCollection");
+    assertEquals(Array.isArray(geoData.features), true);
+  });
+} else {
+  console.log("No DATAWRAPPER_KEY in process.env");
+}

--- a/test/unit/methods/toDW.test.ts
+++ b/test/unit/methods/toDW.test.ts
@@ -1,0 +1,50 @@
+import { assertEquals } from "@std/assert";
+import { SimpleDB } from "../../../src/index.ts";
+
+const apiKey = Deno.env.get("DATAWRAPPER_KEY");
+if (typeof apiKey === "string" && apiKey !== "") {
+  Deno.test("should write the data to a Datawrapper chart", {
+    sanitizeResources: false,
+  }, async () => {
+    const sdb = new SimpleDB();
+    const table = sdb.newTable();
+    await table.loadArray([
+      { salary: 75000, hireDate: "2022-12-15" },
+      { salary: 80000, hireDate: "2023-01-20" },
+    ]);
+    await table.toDW("ntURh");
+
+    // Just making sure it doesn't crash for now.
+    assertEquals(true, true);
+  });
+
+  Deno.test("should write the data to a Datawrapper chart with a note", {
+    sanitizeResources: false,
+  }, async () => {
+    const sdb = new SimpleDB();
+    const table = sdb.newTable();
+    await table.loadArray([
+      { salary: 75000, hireDate: "2022-12-15" },
+    ]);
+    await table.toDW("ntURh", { note: "Last updated: June 2026" });
+
+    // Just making sure it doesn't crash for now.
+    assertEquals(true, true);
+  });
+
+  Deno.test("should write the data to a Datawrapper chart and republish", {
+    sanitizeResources: false,
+  }, async () => {
+    const sdb = new SimpleDB();
+    const table = sdb.newTable();
+    await table.loadArray([
+      { salary: 75000, hireDate: "2022-12-15" },
+    ]);
+    await table.toDW("ntURh", { republish: true });
+
+    // Just making sure it doesn't crash for now.
+    assertEquals(true, true);
+  });
+} else {
+  console.log("No DATAWRAPPER_KEY in process.env");
+}

--- a/test/unit/methods/toGeoDW.test.ts
+++ b/test/unit/methods/toGeoDW.test.ts
@@ -1,0 +1,49 @@
+import { assertEquals } from "@std/assert";
+import { SimpleDB } from "../../../src/index.ts";
+
+const apiKey = Deno.env.get("DATAWRAPPER_KEY");
+if (typeof apiKey === "string" && apiKey !== "") {
+  Deno.test("should write geo data to a Datawrapper map", {
+    sanitizeResources: false,
+  }, async () => {
+    const sdb = new SimpleDB();
+    const table = sdb.newTable();
+    await table.loadGeoData(
+      "test/geodata/files/CanadianProvincesAndTerritories.json",
+    );
+    await table.toGeoDW("lDO6F");
+
+    // Just making sure it doesn't crash for now.
+    assertEquals(true, true);
+  });
+
+  Deno.test("should write geo data to a Datawrapper map with a note", {
+    sanitizeResources: false,
+  }, async () => {
+    const sdb = new SimpleDB();
+    const table = sdb.newTable();
+    await table.loadGeoData(
+      "test/geodata/files/CanadianProvincesAndTerritories.json",
+    );
+    await table.toGeoDW("lDO6F", { note: "Last updated: June 2026" });
+
+    // Just making sure it doesn't crash for now.
+    assertEquals(true, true);
+  });
+
+  Deno.test("should write geo data to a Datawrapper map and republish", {
+    sanitizeResources: false,
+  }, async () => {
+    const sdb = new SimpleDB();
+    const table = sdb.newTable();
+    await table.loadGeoData(
+      "test/geodata/files/CanadianProvincesAndTerritories.json",
+    );
+    await table.toGeoDW("lDO6F", { republish: true });
+
+    // Just making sure it doesn't crash for now.
+    assertEquals(true, true);
+  });
+} else {
+  console.log("No DATAWRAPPER_KEY in process.env");
+}


### PR DESCRIPTION
## Summary

- Adds `toDW` and `loadDW` to push/pull CSV data between a `SimpleTable` and a Datawrapper chart or table
- Adds `toGeoDW` and `loadGeoDW` to push/pull GeoJSON data between a `SimpleTable` and a Datawrapper map
- All four methods support a custom `apiKey` env var name (defaults to `DATAWRAPPER_KEY`); `toDW` and `toGeoDW` also accept `note` and `republish` options
- `loadGeoDW` temporarily writes the JSON to `.sda-cache/<chartId>.json` (Node-compatible) and removes it after loading

Closes #1215

## Test plan

- [ ] Tests in `test/unit/methods/toDW.test.ts`, `loadDW.test.ts`, `toGeoDW.test.ts`, `loadGeoDW.test.ts` run and pass when `DATAWRAPPER_KEY` is set in `.env`
- [ ] Tests are skipped gracefully when the key is absent (matching the Google Sheets test pattern)
