### PR TITLE
Clarify environment-variable configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,12 @@ await sdb.close();
 
 ![Map showing the wildfires in Canada in 2023.](./assets/map.png)
 
+Google Sheets, Datawrapper, and AI methods can read configuration from
+environment variables: named values made available to the running program. A
+`.env` file is one way to define them, but your runtime must load the file. For
+example, with Deno, run `deno run -A --env-file=.env analysis.ts`. Do not commit
+real credentials to source control.
+
 ### Google Sheets
 
 The
@@ -554,10 +560,8 @@ await sdb.close();
 ### AI
 
 SDA can use LLMs and embedding models to enrich data, search text, and answer
-questions based on the contents of a table. The examples below read their AI
-configuration from environment variables. Put one of the following
-configurations in your `.env` file and make sure your runtime loads it. For
-example, with Deno, run `deno run -A --env-file=.env analysis.ts`.
+questions based on the contents of a table. Choose one of the following `.env`
+configurations.
 
 For the Gemini API:
 
@@ -590,10 +594,10 @@ AI_EMBEDDINGS_MODEL=nomic-embed-text
 ```
 
 `AI_PROVIDER` and `AI_MODEL` configure generation, while their `AI_EMBEDDINGS_*`
-counterparts configure vector search; `aiRAG()` uses both. Gemini authenticates
-with `AI_KEY`, or with `AI_PROJECT` and `AI_LOCATION` for Vertex AI. Method
-options override environment variables. Do not commit real credentials to source
-control.
+counterparts configure embeddings, including embeddings used for vector search;
+`aiRAG()` uses both pairs. Gemini authenticates with `AI_KEY`, or with
+`AI_PROJECT` and `AI_LOCATION` for Vertex AI. Method options override the
+corresponding environment values.
 
 SDA's AI capabilities come from
 [`journalism-ai`](https://jsr.io/@nshiab/journalism-ai). By default, LLM

--- a/README.md
+++ b/README.md
@@ -476,9 +476,48 @@ await sdb.close();
 ### AI
 
 SDA can use LLMs and embedding models to enrich data, search text, and answer
-questions based on the contents of a table. The examples below rely on
-environment variables to connect to an AI provider and select a model. Click the
-relevant documentation links below for more information.
+questions based on the contents of a table. The examples below read their AI
+configuration from environment variables. Put one of the following
+configurations in your `.env` file and make sure your runtime loads it. For
+example, with Deno, run `deno run -A --env-file=.env analysis.ts`.
+
+For the Gemini API:
+
+```dotenv
+AI_PROVIDER=gemini
+AI_MODEL=gemini-3-flash-preview
+AI_EMBEDDINGS_PROVIDER=gemini
+AI_EMBEDDINGS_MODEL=gemini-embedding-001
+AI_KEY=your-gemini-api-key
+```
+
+For Vertex AI, replace `AI_KEY` with your Google Cloud project and location:
+
+```dotenv
+AI_PROVIDER=gemini
+AI_MODEL=gemini-3-flash-preview
+AI_EMBEDDINGS_PROVIDER=gemini
+AI_EMBEDDINGS_MODEL=gemini-embedding-001
+AI_PROJECT=my-google-cloud-project
+AI_LOCATION=us-central1
+```
+
+For local Ollama models:
+
+```dotenv
+AI_PROVIDER=ollama
+AI_MODEL=gemma3:4b
+AI_EMBEDDINGS_PROVIDER=ollama
+AI_EMBEDDINGS_MODEL=nomic-embed-text
+```
+
+`aiRowByRow()` and `aiQuery()` use `AI_PROVIDER` and `AI_MODEL`.
+`aiEmbeddings()`, `aiVectorSimilarity()`, and the vector-search portion of
+`hybridSearch()` use `AI_EMBEDDINGS_PROVIDER` and `AI_EMBEDDINGS_MODEL`.
+`aiRAG()` uses both pairs. Gemini methods authenticate with `AI_KEY`, or with
+both `AI_PROJECT` and `AI_LOCATION` for Vertex AI. Options passed directly to a
+method override the corresponding environment variables. Do not commit real
+credentials to source control.
 
 SDA's AI capabilities come from
 [`journalism-ai`](https://jsr.io/@nshiab/journalism-ai). By default, LLM
@@ -495,6 +534,7 @@ record row-level errors, making it useful for cleaning, extracting, classifying,
 and enriching data at scale.
 
 ```ts
+// Uses AI_PROVIDER, AI_MODEL, and any required credentials from .env.
 import { SimpleDB } from "@nshiab/simple-data-analysis";
 
 const sdb = new SimpleDB();
@@ -529,6 +569,8 @@ and
 methods used by `hybridSearch` are also available directly.
 
 ```ts
+// Uses AI_EMBEDDINGS_PROVIDER, AI_EMBEDDINGS_MODEL, and any required credentials
+// from .env.
 import { SimpleDB } from "@nshiab/simple-data-analysis";
 
 const sdb = new SimpleDB();
@@ -557,6 +599,7 @@ method first retrieves relevant rows with hybrid search, then asks an LLM to
 answer using only those rows.
 
 ```ts
+// Uses both AI provider/model pairs and any required credentials from .env.
 import { SimpleDB } from "@nshiab/simple-data-analysis";
 
 const sdb = new SimpleDB();
@@ -586,6 +629,7 @@ method turns a natural-language instruction into a SQL query and executes it on
 the table.
 
 ```ts
+// Uses AI_PROVIDER, AI_MODEL, and any required credentials from .env.
 import { SimpleDB } from "@nshiab/simple-data-analysis";
 
 const sdb = new SimpleDB();

--- a/README.md
+++ b/README.md
@@ -511,13 +511,11 @@ AI_EMBEDDINGS_PROVIDER=ollama
 AI_EMBEDDINGS_MODEL=nomic-embed-text
 ```
 
-`aiRowByRow()` and `aiQuery()` use `AI_PROVIDER` and `AI_MODEL`.
-`aiEmbeddings()`, `aiVectorSimilarity()`, and the vector-search portion of
-`hybridSearch()` use `AI_EMBEDDINGS_PROVIDER` and `AI_EMBEDDINGS_MODEL`.
-`aiRAG()` uses both pairs. Gemini methods authenticate with `AI_KEY`, or with
-both `AI_PROJECT` and `AI_LOCATION` for Vertex AI. Options passed directly to a
-method override the corresponding environment variables. Do not commit real
-credentials to source control.
+`AI_PROVIDER` and `AI_MODEL` configure generation, while their `AI_EMBEDDINGS_*`
+counterparts configure vector search; `aiRAG()` uses both. Gemini authenticates
+with `AI_KEY`, or with `AI_PROJECT` and `AI_LOCATION` for Vertex AI. Method
+options override environment variables. Do not commit real credentials to source
+control.
 
 SDA's AI capabilities come from
 [`journalism-ai`](https://jsr.io/@nshiab/journalism-ai). By default, LLM

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ const data = await sdb
   .log();
 
 await data.writeData("sda/output/averageTemperatures.csv");
+
 await sdb.close();
 ```
 
@@ -473,6 +474,83 @@ await sdb.close();
 
 ![Map showing the wildfires in Canada in 2023.](./assets/map.png)
 
+### Google Sheets
+
+The
+[`toSheet`](https://jsr.io/@nshiab/simple-data-analysis/doc/~/SimpleTable.prototype.toSheet)
+method sends a table directly to Google Sheets. Authenticate with a service
+account by setting its email and private key in `.env`:
+
+```dotenv
+GOOGLE_SERVICE_ACCOUNT_EMAIL=service-account@example.iam.gserviceaccount.com
+GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+```
+
+Alternatively, point `GOOGLE_APPLICATION_CREDENTIALS` to the service-account
+JSON file:
+
+```dotenv
+GOOGLE_APPLICATION_CREDENTIALS=./service-account.json
+```
+
+Share the destination spreadsheet with the service-account email before running
+the example. You can also pass credentials directly through `toSheet()` options.
+The `loadSheet()` method uses the same environment variables.
+
+```ts
+// Uses Google service-account credentials from .env.
+import { SimpleDB } from "@nshiab/simple-data-analysis";
+
+const sdb = new SimpleDB();
+const temperatures = sdb.newTable("temperatures");
+
+await temperatures
+  .loadData(
+    "https://raw.githubusercontent.com/nshiab/simple-data-analysis/main/test/data/files/dailyTemperatures.csv",
+  )
+  .renameColumns({ t: "temperature", id: "station" })
+  .selectColumns(["station", "time", "temperature"])
+  .toSheet("https://docs.google.com/spreadsheets/d/.../edit#gid=0");
+
+await sdb.close();
+```
+
+### Datawrapper
+
+The
+[`toDatawrapper`](https://jsr.io/@nshiab/simple-data-analysis/doc/~/SimpleTable.prototype.toDatawrapper)
+method sends a table directly to a Datawrapper chart or table. Add your API key
+to `.env`:
+
+```dotenv
+DATAWRAPPER_KEY=your-datawrapper-api-key
+```
+
+The chart ID is the short identifier in its Datawrapper URL. Set `apiKeyEnvVar`
+in the method options if you store the key under a different
+environment-variable name. For maps, use
+[`toGeoDatawrapper`](https://jsr.io/@nshiab/simple-data-analysis/doc/~/SimpleTable.prototype.toGeoDatawrapper)
+with the same API key. The `loadDatawrapper()` and `loadGeoDatawrapper()`
+methods also use it.
+
+```ts
+// Uses DATAWRAPPER_KEY from .env.
+import { SimpleDB } from "@nshiab/simple-data-analysis";
+
+const sdb = new SimpleDB();
+const temperatures = sdb.newTable("temperatures");
+
+await temperatures
+  .loadData(
+    "https://raw.githubusercontent.com/nshiab/simple-data-analysis/main/test/data/files/dailyTemperatures.csv",
+  )
+  .renameColumns({ t: "temperature", id: "station" })
+  .selectColumns(["station", "time", "temperature"])
+  .toDatawrapper("myChartId", { republish: true });
+
+await sdb.close();
+```
+
 ### AI
 
 SDA can use LLMs and embedding models to enrich data, search text, and answer
@@ -536,8 +614,9 @@ and enriching data at scale.
 import { SimpleDB } from "@nshiab/simple-data-analysis";
 
 const sdb = new SimpleDB();
-const cities = await sdb
-  .newTable("cities")
+const cities = sdb.newTable("cities");
+
+await cities
   .loadArray([
     { city: "Marrakech" },
     { city: "Kyoto" },
@@ -572,9 +651,10 @@ methods used by `hybridSearch` are also available directly.
 import { SimpleDB } from "@nshiab/simple-data-analysis";
 
 const sdb = new SimpleDB();
+const recipes = sdb.newTable("recipes");
+
 // We search both the meaning and the wording of each recipe.
-const results = await sdb
-  .newTable("recipes")
+await recipes
   .loadData(
     "https://raw.githubusercontent.com/nshiab/simple-data-analysis/main/test/data/files/recipesClean.parquet",
   )
@@ -586,6 +666,7 @@ const results = await sdb
     { outputTable: "results", verbose: true },
   )
   .log(); // For example: "Butter Pie" (keyword) and "Croissant" (semantic).
+
 await sdb.close();
 ```
 
@@ -617,6 +698,7 @@ const answer = await sdb
   );
 
 console.log(answer);
+
 await sdb.close();
 ```
 
@@ -632,8 +714,9 @@ the table.
 import { SimpleDB } from "@nshiab/simple-data-analysis";
 
 const sdb = new SimpleDB();
-const averageTemperatures = await sdb
-  .newTable("temperatures")
+const temperatures = sdb.newTable("temperatures");
+
+await temperatures
   .loadData(
     "https://raw.githubusercontent.com/nshiab/simple-data-analysis/main/test/data/files/dailyTemperatures.csv",
   )
@@ -643,6 +726,7 @@ const averageTemperatures = await sdb
     { verbose: true },
   )
   .log();
+
 await sdb.close();
 ```
 

--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ const cities = await sdb
     "city",
     ["country", "continent"],
     "Give me the country and continent of the city.",
-    { concurrency: 5, errorColumn: "error" },
+    { concurrency: 5, errorColumn: "error", verbose: true },
   )
   .log();
 
@@ -585,7 +585,7 @@ const results = await sdb
     "Dish",
     "Recipe",
     5,
-    { outputTable: "results" },
+    { outputTable: "results", verbose: true },
   )
   .log(); // For example: "Butter Pie" (keyword) and "Croissant" (semantic).
 await sdb.close();
@@ -615,6 +615,7 @@ const answer = await sdb
     "Dish",
     "Recipe",
     10,
+    { verbose: true },
   );
 
 console.log(answer);
@@ -641,6 +642,7 @@ const averageTemperatures = await sdb
   .renameColumns({ t: "temperature", id: "station" })
   .aiQuery(
     "Compute the average temperature for each station with two decimals.",
+    { verbose: true },
   )
   .log();
 await sdb.close();

--- a/llm.md
+++ b/llm.md
@@ -663,10 +663,15 @@ pool with configurable batching and concurrency.
 This method automatically appends instructions to your prompt; set `verbose` to
 `true` to see the full prompt.
 
-This method supports Gemini, Vertex AI, and Ollama. Set `generation.provider`
-explicitly, or omit it to use `AI_PROVIDER`. All other `generation` fields match
-the selected `askGemini` or `askOllama` function from journalism-ai. Model and
-credentials can also come from environment variables.
+This method supports Gemini, Vertex AI, and Ollama. When the corresponding
+`generation` options are omitted, configuration comes from `AI_PROVIDER`
+(`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example,
+`"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY`
+(for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
+`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
+Explicit `generation` options override the corresponding environment variables;
+all other fields match the selected `askGemini` or `askOllama` function from
+journalism-ai.
 
 For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set
 `AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
@@ -788,6 +793,10 @@ const people = await sdb
 ```
 
 ```ts
+// Set these environment variables before running:
+// AI_PROVIDER=gemini
+// AI_MODEL=gemini-3-flash-preview
+// AI_KEY=your-gemini-api-key
 const cities = await sdb
   .newTable("cities")
   .loadArray([
@@ -826,10 +835,15 @@ const names = await sdb
 Generates embeddings for a specified text column and stores the results in a new
 column.
 
-This method supports Gemini, Vertex AI, and Ollama embeddings. Set
-`embeddings.provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`; all
-other fields match `getEmbedding` from journalism-ai. Model and credentials can
-also come from environment variables.
+This method supports Gemini, Vertex AI, and Ollama embeddings. When the
+corresponding `embeddings` options are omitted, configuration comes from
+`AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`),
+`AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or
+`"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example,
+`"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
+`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
+Explicit `embeddings` options override the corresponding environment variables;
+all other fields match `getEmbedding` from journalism-ai.
 
 For Ollama, set `AI_EMBEDDINGS_PROVIDER=ollama`, ensure Ollama is running, and
 set `AI_EMBEDDINGS_MODEL`, or pass `{ provider: "ollama", ... }` through
@@ -902,6 +916,10 @@ The table, so methods can be chained.
 ##### Examples
 
 ```ts
+// Set these environment variables before running:
+// AI_EMBEDDINGS_PROVIDER=gemini
+// AI_EMBEDDINGS_MODEL=gemini-embedding-001
+// AI_KEY=your-gemini-api-key
 const food = await sdb
   .newTable("food")
   .loadArray([
@@ -913,10 +931,6 @@ const food = await sdb
     { food: "tacos" },
   ])
   .aiEmbeddings("food", "embeddings", {
-    embeddings: {
-      provider: "gemini",
-      model: "gemini-embedding-001",
-    },
     rateLimitPerMinute: 15,
     createIndex: true,
     verbose: true,
@@ -940,8 +954,15 @@ content based on their embeddings. This method is useful for semantic search and
 text similarity tasks, computing cosine distance and sorting results by
 similarity.
 
-To create the query embedding, omit `embeddings` to use environment variables or
-pass provider-specific options matching `getEmbedding` from journalism-ai.
+To create the query embedding, pass provider-specific options matching
+`getEmbedding` from journalism-ai or use environment variables. When the
+corresponding `embeddings` options are omitted, configuration comes from
+`AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`),
+`AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or
+`"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example,
+`"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
+`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
+Explicit `embeddings` options override the corresponding environment variables.
 
 Gemini, Vertex AI, and Ollama are supported. The selected provider and model
 must match those used to create the stored embedding column so the vectors share
@@ -1007,6 +1028,10 @@ The table that will contain the similarity results, so methods can be chained.
 ##### Examples
 
 ```ts
+// Set these environment variables before running:
+// AI_EMBEDDINGS_PROVIDER=gemini
+// AI_EMBEDDINGS_MODEL=gemini-embedding-001
+// AI_KEY=your-gemini-api-key
 const similarFood = await sdb
   .newTable("food")
   .loadArray([
@@ -1017,18 +1042,9 @@ const similarFood = await sdb
     { food: "salad" },
     { food: "tacos" },
   ])
-  .aiEmbeddings("food", "embeddings", {
-    embeddings: {
-      provider: "gemini",
-      model: "gemini-embedding-001",
-    },
-  })
+  .aiEmbeddings("food", "embeddings")
   .aiVectorSimilarity("italian food", "embeddings", 3, {
     createIndex: true,
-    embeddings: {
-      provider: "gemini",
-      model: "gemini-embedding-001",
-    },
     minSimilarity: 0.6,
     similarityColumn: "score",
   })
@@ -1070,9 +1086,15 @@ before replacement. This provenance survives reopening a DuckDB database.
 Remove `.journalism-cache` and `.sda-cache` to clear existing cache entries.
 Remember to add both directories to your `.gitignore`.
 
-This method supports Gemini, Vertex AI, and Ollama embeddings. Set
-`embeddings.provider` explicitly or omit it to use environment selection; all
-other fields match `getEmbedding` from journalism-ai.
+This method supports Gemini, Vertex AI, and Ollama embeddings. When the
+corresponding `embeddings` options are omitted, configuration comes from
+`AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`),
+`AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or
+`"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example,
+`"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
+`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
+Explicit `embeddings` options override the corresponding environment variables;
+all other fields match `getEmbedding` from journalism-ai.
 
 The selected embedding provider is used for both stored row embeddings and the
 query embedding.
@@ -1169,16 +1191,16 @@ The table that will contain the search results, so methods can be chained.
 ##### Examples
 
 ```ts
+// Set these environment variables before running:
+// AI_EMBEDDINGS_PROVIDER=gemini
+// AI_EMBEDDINGS_MODEL=gemini-embedding-001
+// AI_KEY=your-gemini-api-key
 // Load a dataset of recipes
 const sdb = new SimpleDB();
 const results = await sdb
   .newTable("recipes")
   .loadData("recipes.parquet")
   .hybridSearch("buttery pastry for breakfast", "Dish", "Recipe", 10, {
-    embeddings: {
-      provider: "gemini",
-      model: "gemini-embedding-001",
-    },
     verbose: true,
   })
   .log();
@@ -1215,13 +1237,20 @@ corresponding caches.
 Remove `.journalism-cache` and `.sda-cache` to clear existing cache entries.
 Remember to add both directories to your `.gitignore`.
 
-Generation and embeddings are independently configurable. Set either nested
-`provider` explicitly or omit it to use that provider's environment selection;
-all remaining fields match journalism-ai.
+Generation and embeddings are independently configurable. When the corresponding
+options are omitted, generation uses `AI_PROVIDER` (`"gemini"` or `"ollama"`;
+defaults to `"gemini"`) and `AI_MODEL` (for example, `"gemini-3-flash-preview"`
+or `"gemma3:4b"`), while embeddings use `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or
+`"ollama"`; defaults to `"gemini"`) and `AI_EMBEDDINGS_MODEL` (for example,
+`"gemini-embedding-001"` or `"nomic-embed-text"`). Gemini generation and
+embeddings use either `AI_KEY` (for example, `"your-gemini-api-key"`) or both
+`AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for
+example, `"us-central1"`). Explicit nested options override the corresponding
+environment variables; all remaining fields match journalism-ai.
 
 For example, `generation.provider` can be `"gemini"` while `embeddings.provider`
-is `"ollama"`. Environment-only mixed providers use `AI_PROVIDER` and
-`AI_EMBEDDINGS_PROVIDER`.
+is `"ollama"`; the same mix can be selected through `AI_PROVIDER=gemini` and
+`AI_EMBEDDINGS_PROVIDER=ollama`.
 
 Ollama temperature defaults to 0. Gemini uses the provider's default
 temperature.
@@ -1323,6 +1352,12 @@ context.
 ##### Examples
 
 ```ts
+// Set these environment variables before running:
+// AI_PROVIDER=gemini
+// AI_MODEL=gemini-3-flash-preview
+// AI_KEY=your-gemini-api-key
+// AI_EMBEDDINGS_PROVIDER=ollama
+// AI_EMBEDDINGS_MODEL=nomic-embed-text
 // Load a dataset of recipes
 const sdb = new SimpleDB();
 const answer = await sdb
@@ -1333,17 +1368,7 @@ const answer = await sdb
     "Dish", // Column with unique IDs
     "Recipe", // Column with text to search
     10, // The 10 most relevant recipes passed to the LLM
-    {
-      generation: {
-        provider: "gemini",
-        model: "gemini-3-flash-preview",
-      },
-      embeddings: {
-        provider: "ollama",
-        model: "nomic-embed-text",
-      },
-      verbose: true, // Log debugging information and timings
-    },
+    { verbose: true }, // Log debugging information and timings
   );
 
 console.log(answer);
@@ -1371,9 +1396,14 @@ Generates and executes a SQL query based on a prompt. Additional instructions,
 such as column types, are automatically added to your prompt. Set `verbose` to
 `true` to see the full prompt.
 
-This method supports Gemini, Vertex AI, and Ollama. Set `generation.provider`
-explicitly or omit it to use environment selection; all other relevant fields
-match `askGemini` or `askOllama` from journalism-ai.
+This method supports Gemini, Vertex AI, and Ollama. When the corresponding
+`generation` options are omitted, configuration comes from `AI_PROVIDER`
+(`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example,
+`"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY`
+(for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
+`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
+Explicit `generation` options override the corresponding environment variables;
+all other relevant fields match `askGemini` or `askOllama` from journalism-ai.
 
 For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set
 `AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
@@ -1417,16 +1447,16 @@ The table that will contain the query results, so methods can be chained.
 ##### Examples
 
 ```ts
+// Set these environment variables before running:
+// AI_PROVIDER=gemini
+// AI_MODEL=gemini-3-flash-preview
+// AI_KEY=your-gemini-api-key
 // The AI will generate a query that will be executed, and
 // the result will replace the existing table.
 // If run again, it will use the previous query from the cache.
 // Don't forget to add .journalism-cache to your .gitignore file!
 const averageSalaryByDepartment = await table
   .aiQuery("Give me the average salary by department", {
-    generation: {
-      provider: "gemini",
-      model: "gemini-3-flash-preview",
-    },
     verbose: true,
   })
   .log();
@@ -1464,11 +1494,13 @@ function from the
 its documentation for more details.
 
 By default, the selected tab is overwritten and values are written without
-Google Sheets interpretation. Authentication is handled via environment
-variables (GOOGLE_PRIVATE_KEY and GOOGLE_SERVICE_ACCOUNT_EMAIL). Alternatively,
-you can use GOOGLE_APPLICATION_CREDENTIALS pointing to a service account JSON
-file. For detailed setup instructions, refer to the node-google-spreadsheet
-authentication guide:
+Google Sheets interpretation. Authentication uses `GOOGLE_SERVICE_ACCOUNT_EMAIL`
+(for example, `"service-account@example.iam.gserviceaccount.com"`) with
+`GOOGLE_PRIVATE_KEY` (for example, `"-----BEGIN PRIVATE KEY-----\n..."`).
+Alternatively, set `GOOGLE_APPLICATION_CREDENTIALS` to a service-account JSON
+path (for example, `"./service-account.json"`). Explicit `options.credentials`
+override these environment variables. For detailed setup instructions, refer to
+the node-google-spreadsheet authentication guide:
 https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication.
 
 ##### Signature
@@ -1506,6 +1538,9 @@ A promise that resolves when the data has been written to the sheet.
 ##### Examples
 
 ```ts
+// Set these environment variables before running:
+// GOOGLE_SERVICE_ACCOUNT_EMAIL=service-account@example.iam.gserviceaccount.com
+// GOOGLE_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\n...
 // Load, transform, and write data to a Google Sheet
 await sdb
   .newTable()
@@ -1560,14 +1595,14 @@ Loads data from a Google Sheet into the table. This method uses the
 [journalism library](https://jsr.io/@nshiab/journalism). Refer to its
 documentation for more details.
 
-By default, authentication is handled via environment variables
-(GOOGLE_PRIVATE_KEY and GOOGLE_SERVICE_ACCOUNT_EMAIL). Alternatively, you can
-use GOOGLE_APPLICATION_CREDENTIALS pointing to a service account JSON file. For
-detailed setup instructions, refer to the node-google-spreadsheet authentication
-guide:
-https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication.
-The download is queued and runs in chain order at the next awaited observer or
-`run()` call.
+By default, authentication uses `GOOGLE_SERVICE_ACCOUNT_EMAIL` (for example,
+`"service-account@example.iam.gserviceaccount.com"`) with `GOOGLE_PRIVATE_KEY`
+(for example, `"-----BEGIN PRIVATE KEY-----\n..."`). Alternatively, set
+`GOOGLE_APPLICATION_CREDENTIALS` to a service-account JSON path (for example,
+`"./service-account.json"`). Use `options.apiEmailEnvVar` and
+`options.apiKeyEnvVar` to read the email and private key from custom variable
+names instead. The download is queued and runs in chain order at the next
+awaited observer or `run()` call.
 
 ##### Signature
 
@@ -1584,9 +1619,11 @@ loadSheet(sheetUrl: string, options?: { skip?: number; apiEmailEnvVar?: string; 
   before reading data. Useful when the sheet contains metadata or headers that
   should not be included in the data.
 - **`options.apiEmailEnvVar`**: The name of the environment variable that stores
-  your API email.
+  your Google service-account email (for example, `"MY_GOOGLE_EMAIL"`). Defaults
+  to `"GOOGLE_SERVICE_ACCOUNT_EMAIL"`.
 - **`options.apiKeyEnvVar`**: The name of the environment variable that stores
-  your API key.
+  your Google service-account private key (for example,
+  `"MY_GOOGLE_PRIVATE_KEY"`). Defaults to `"GOOGLE_PRIVATE_KEY"`.
 
 ##### Returns
 
@@ -1595,6 +1632,9 @@ The table, so methods can be chained.
 ##### Examples
 
 ```ts
+// Set these environment variables before running:
+// GOOGLE_SERVICE_ACCOUNT_EMAIL=service-account@example.iam.gserviceaccount.com
+// GOOGLE_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\n...
 // Load data from a Google Sheet
 const sheetData = await sdb
   .newTable("sheetData")
@@ -1615,8 +1655,9 @@ const sheetData = await table
 
 Writes the table data as CSV to a Datawrapper chart or table.
 
-Authentication is handled via an API key stored in the environment variable
-`DATAWRAPPER_KEY`, or a custom variable name via `options.apiKeyEnvVar`.
+Authentication uses the API key in `DATAWRAPPER_KEY` (for example,
+`"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a
+custom environment variable instead.
 
 ##### Signature
 
@@ -1644,6 +1685,7 @@ A promise that resolves when the data has been sent to Datawrapper.
 ##### Examples
 
 ```ts
+// Set DATAWRAPPER_KEY=your-datawrapper-api-key before running.
 // Load, transform, and send data to a Datawrapper chart
 await sdb
   .newTable()
@@ -1664,10 +1706,10 @@ await table.toDatawrapper("myChartId", {
 
 Loads data from a Datawrapper chart or table into the table.
 
-Authentication is handled via an API key stored in the environment variable
-`DATAWRAPPER_KEY`, or a custom variable name via `options.apiKeyEnvVar`. The
-download is queued and runs in chain order at the next awaited observer or
-`run()` call.
+Authentication uses the API key in `DATAWRAPPER_KEY` (for example,
+`"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a
+custom environment variable instead. The download is queued and runs in chain
+order at the next awaited observer or `run()` call.
 
 ##### Signature
 
@@ -1691,6 +1733,7 @@ The table, so methods can be chained.
 ##### Examples
 
 ```ts
+// Set DATAWRAPPER_KEY=your-datawrapper-api-key before running.
 // Load data from a Datawrapper chart
 const chartData = await sdb
   .newTable("chartData")
@@ -1702,8 +1745,9 @@ const chartData = await sdb
 
 Writes the table's geospatial data as GeoJSON to a Datawrapper map.
 
-Authentication is handled via an API key stored in the environment variable
-`DATAWRAPPER_KEY`, or a custom variable name via `options.apiKeyEnvVar`.
+Authentication uses the API key in `DATAWRAPPER_KEY` (for example,
+`"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a
+custom environment variable instead.
 
 ##### Signature
 
@@ -1732,6 +1776,7 @@ A promise that resolves when the data has been sent to Datawrapper.
 ##### Examples
 
 ```ts
+// Set DATAWRAPPER_KEY=your-datawrapper-api-key before running.
 // Load, transform, and send geospatial data to a Datawrapper map
 await sdb
   .newTable()
@@ -1752,8 +1797,9 @@ await table.toGeoDatawrapper("myMapId", {
 
 Loads geospatial data from a Datawrapper map into the table.
 
-Authentication is handled via an API key stored in the environment variable
-`DATAWRAPPER_KEY`, or a custom variable name via `options.apiKeyEnvVar`.
+Authentication uses the API key in `DATAWRAPPER_KEY` (for example,
+`"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a
+custom environment variable instead.
 
 The data is temporarily written to `.sda-cache/tmp/dataviz/<uuid>.geojson` and
 removed after loading. Remember to add `.sda-cache` to your `.gitignore`. The
@@ -1782,6 +1828,7 @@ The table, so methods can be chained.
 ##### Examples
 
 ```ts
+// Set DATAWRAPPER_KEY=your-datawrapper-api-key before running.
 // Load geo data from a Datawrapper map
 const mapData = await sdb
   .newTable("mapData")

--- a/llm.md
+++ b/llm.md
@@ -664,16 +664,16 @@ pool with configurable batching and concurrency.
 This method automatically appends instructions to your prompt; set `verbose` to
 `true` to see the full prompt.
 
-This method supports Gemini, Vertex AI, and Ollama. When the corresponding
-`generation` options are omitted, configuration comes from `AI_PROVIDER`
-(`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example,
-`"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY`
-(for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
-`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
-Explicit `generation` options override the corresponding environment variables.
+This method supports Gemini, Vertex AI, and Ollama.
 
-For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set
-`AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
+Environment variables are named configuration values supplied to the running
+process. By default, this method reads `AI_PROVIDER` (`"gemini"` or `"ollama"`;
+defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or
+`"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example,
+`"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
+`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
+Values passed through `generation` override the corresponding environment
+values. When using Ollama, ensure it is running.
 
 To manage rate limits, use `batchSize` to process multiple rows per request and
 `rateLimitPerMinute` to pace requests across the worker pool. The `concurrency`
@@ -717,9 +717,7 @@ aiRowByRow(column: string, newColumn: string | string[], prompt: string, options
   are stored. When omitted, a failed batch throws.
 - **`options.logProgress`**: If `true`, logs request-pool progress. Defaults to
   `false`.
-- **`options.generation`**: Gemini or Ollama generation configuration. Set
-  `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here
-  override the corresponding environment variables.
+- **`options.generation`**: Optional Gemini or Ollama generation configuration.
 - **`options.test`**: A function to validate the returned data. If it throws an
   error, the request will be retried (if `retry` is set). Defaults to
   `undefined`.
@@ -834,18 +832,16 @@ const names = await sdb
 Generates embeddings for a specified text column and stores the results in a new
 column.
 
-This method supports Gemini, Vertex AI, and Ollama embeddings. When the
-corresponding `embeddings` options are omitted, configuration comes from
-`AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`),
-`AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or
-`"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example,
-`"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
-`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
-Explicit `embeddings` options override the corresponding environment variables.
+This method supports Gemini, Vertex AI, and Ollama embeddings.
 
-For Ollama, set `AI_EMBEDDINGS_PROVIDER=ollama`, ensure Ollama is running, and
-set `AI_EMBEDDINGS_MODEL`, or pass `{ provider: "ollama", ... }` through
-`embeddings`.
+Environment variables are named configuration values supplied to the running
+process. By default, this method reads `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or
+`"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example,
+`"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either
+`AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for
+example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example,
+`"us-central1"`). Values passed through `embeddings` override the corresponding
+environment values. When using Ollama, ensure it is running.
 
 To manage rate limits, use `rateLimitPerMinute` to introduce delays between
 requests. For higher rate limits (business/professional accounts), `concurrency`
@@ -898,9 +894,7 @@ aiEmbeddings(column: string, newColumn: string, options?: { embeddings?: { provi
   time and memory usage. Defaults to 16.
 - **`options.concurrency`**: The number of concurrent requests to send. Defaults
   to `1`.
-- **`options.embeddings`**: Gemini or Ollama embedding configuration. Set
-  `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values
-  provided here override the corresponding environment variables.
+- **`options.embeddings`**: Optional Gemini or Ollama embedding configuration.
 - **`options.rateLimitPerMinute`**: The rate limit for AI requests in requests
   per minute. The method will wait between requests if necessary. Defaults to
   `undefined` (no limit).
@@ -952,15 +946,14 @@ content based on their embeddings. This method is useful for semantic search and
 text similarity tasks, computing cosine distance and sorting results by
 similarity.
 
-To create the query embedding, pass `embeddings` options directly or use
-environment variables. When the corresponding `embeddings` options are omitted,
-configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`;
-defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example,
+Environment variables are named configuration values supplied to the running
+process. By default, this method reads `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or
+`"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example,
 `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either
 `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for
 example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example,
-`"us-central1"`). Explicit `embeddings` options override the corresponding
-environment variables.
+`"us-central1"`). Values passed through `embeddings` override the corresponding
+environment values.
 
 Gemini, Vertex AI, and Ollama are supported. The selected provider and model
 must match those used to create the stored embedding column so the vectors share
@@ -1013,9 +1006,7 @@ aiVectorSimilarity(text: string, column: string, nbResults: number, options?: { 
 - **`options.outputTable`**: The name of the output table where the results will
   be stored. If not provided, the current table will be modified. Defaults to
   `undefined`.
-- **`options.embeddings`**: Gemini or Ollama embedding configuration. Set
-  `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values
-  provided here override the corresponding environment variables.
+- **`options.embeddings`**: Optional Gemini or Ollama embedding configuration.
 - **`options.verbose`**: If `true`, logs additional debugging information.
   Defaults to `false`.
 
@@ -1084,14 +1075,16 @@ before replacement. This provenance survives reopening a DuckDB database.
 Remove `.journalism-cache` and `.sda-cache` to clear existing cache entries.
 Remember to add both directories to your `.gitignore`.
 
-This method supports Gemini, Vertex AI, and Ollama embeddings. When the
-corresponding `embeddings` options are omitted, configuration comes from
-`AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`),
-`AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or
-`"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example,
-`"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
-`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
-Explicit `embeddings` options override the corresponding environment variables.
+This method supports Gemini, Vertex AI, and Ollama embeddings.
+
+Environment variables are named configuration values supplied to the running
+process. By default, this method reads `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or
+`"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example,
+`"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either
+`AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for
+example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example,
+`"us-central1"`). Values passed through `embeddings` override the corresponding
+environment values.
 
 The selected embedding provider is used for both stored row embeddings and the
 query embedding.
@@ -1119,9 +1112,7 @@ hybridSearch(query: string, idColumn: string, textColumn: string, nbResults: num
   through.
 - **`nbResults`**: The number of most similar rows to retrieve.
 - **`options`**: Configuration options for the hybrid search.
-- **`options.embeddings`**: Gemini or Ollama embedding configuration. Set
-  `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values
-  provided here override the corresponding environment variables.
+- **`options.embeddings`**: Optional Gemini or Ollama embedding configuration.
 - **`options.verbose`**: If `true`, logs additional debugging information.
   Defaults to `false`.
 - **`options.createIndex`**: If `true`, creates an HNSW index when vector search
@@ -1234,16 +1225,18 @@ corresponding caches.
 Remove `.journalism-cache` and `.sda-cache` to clear existing cache entries.
 Remember to add both directories to your `.gitignore`.
 
-Generation and embeddings are independently configurable. When the corresponding
-options are omitted, generation uses `AI_PROVIDER` (`"gemini"` or `"ollama"`;
+Generation and embeddings are independently configurable.
+
+Environment variables are named configuration values supplied to the running
+process. By default, generation reads `AI_PROVIDER` (`"gemini"` or `"ollama"`;
 defaults to `"gemini"`) and `AI_MODEL` (for example, `"gemini-3-flash-preview"`
-or `"gemma3:4b"`), while embeddings use `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or
+or `"gemma3:4b"`), while embeddings read `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or
 `"ollama"`; defaults to `"gemini"`) and `AI_EMBEDDINGS_MODEL` (for example,
 `"gemini-embedding-001"` or `"nomic-embed-text"`). Gemini generation and
-embeddings use either `AI_KEY` (for example, `"your-gemini-api-key"`) or both
-`AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for
-example, `"us-central1"`). Explicit nested options override the corresponding
-environment variables.
+embeddings also read either `AI_KEY` (for example, `"your-gemini-api-key"`) or
+both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION`
+(for example, `"us-central1"`). Values passed through either option override its
+environment defaults.
 
 For example, `generation.provider` can be `"gemini"` while `embeddings.provider`
 is `"ollama"`; the same mix can be selected through `AI_PROVIDER=gemini` and
@@ -1275,12 +1268,8 @@ async aiRAG(query: string, idColumn: string, textColumn: string, nbResults: numb
 - **`nbResults`**: The number of most similar rows to retrieve and use as
   context for the AI.
 - **`options`**: Configuration options for the RAG process.
-- **`options.generation`**: Gemini or Ollama generation configuration. Set
-  `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here
-  override the corresponding environment variables.
-- **`options.embeddings`**: Gemini or Ollama embedding configuration. Set
-  `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values
-  provided here override the corresponding environment variables.
+- **`options.generation`**: Optional Gemini or Ollama generation configuration.
+- **`options.embeddings`**: Optional Gemini or Ollama embedding configuration.
 - **`options.verbose`**: If `true`, logs additional debugging information.
   Defaults to `false`.
 - **`options.includeThoughts`**: If `true`, includes the AI model's reasoning
@@ -1393,16 +1382,16 @@ Generates and executes a SQL query based on a prompt. Additional instructions,
 such as column types, are automatically added to your prompt. Set `verbose` to
 `true` to see the full prompt.
 
-This method supports Gemini, Vertex AI, and Ollama. When the corresponding
-`generation` options are omitted, configuration comes from `AI_PROVIDER`
-(`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example,
-`"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY`
-(for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
-`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
-Explicit `generation` options override the corresponding environment variables.
+This method supports Gemini, Vertex AI, and Ollama.
 
-For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set
-`AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
+Environment variables are named configuration values supplied to the running
+process. By default, this method reads `AI_PROVIDER` (`"gemini"` or `"ollama"`;
+defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or
+`"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example,
+`"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
+`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
+Values passed through `generation` override the corresponding environment
+values. When using Ollama, ensure it is running.
 
 Ollama temperature defaults to 0, while Gemini uses the provider's default.
 Provider-specific controls live under `generation`.
@@ -1424,9 +1413,7 @@ aiQuery(prompt: string, options?: { extraInstructions?: string; generation?: { s
 - **`options`**: Configuration options for the AI request.
 - **`options.extraInstructions`**: Additional instructions to append to the
   prompt, providing more context or guidance for the AI.
-- **`options.generation`**: Gemini or Ollama generation configuration. Set
-  `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here
-  override the corresponding environment variables.
+- **`options.generation`**: Optional Gemini or Ollama generation configuration.
 - **`options.outputTable`**: The name of a new table where the results will be
   stored. If not provided, the current table will be replaced with the query
   results.
@@ -1490,13 +1477,16 @@ function from the
 its documentation for more details.
 
 By default, the selected tab is overwritten and values are written without
-Google Sheets interpretation. Authentication uses `GOOGLE_SERVICE_ACCOUNT_EMAIL`
+Google Sheets interpretation.
+
+Environment variables are named configuration values supplied to the running
+process. For authentication, this method reads `GOOGLE_SERVICE_ACCOUNT_EMAIL`
 (for example, `"service-account@example.iam.gserviceaccount.com"`) with
 `GOOGLE_PRIVATE_KEY` (for example, `"-----BEGIN PRIVATE KEY-----\n..."`).
 Alternatively, set `GOOGLE_APPLICATION_CREDENTIALS` to a service-account JSON
-path (for example, `"./service-account.json"`). Explicit `options.credentials`
-override these environment variables. For detailed setup instructions, refer to
-the node-google-spreadsheet authentication guide:
+path (for example, `"./service-account.json"`). Values passed through
+`options.credentials` override these environment values. For detailed setup
+instructions, refer to the node-google-spreadsheet authentication guide:
 https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication.
 
 ##### Signature
@@ -1521,9 +1511,7 @@ async toSheet(sheetUrl: string, options?: { mode?: "overwrite" | "append"; tabTi
   time zone to use it for the timestamp. Available only in overwrite mode.
 - **`options.raw`**: If `true`, writes values without Google Sheets
   interpretation. Defaults to `true`.
-- **`options.credentials`**: Explicit Google service-account credentials. These
-  override credentials provided through environment variables or
-  GOOGLE_APPLICATION_CREDENTIALS.
+- **`options.credentials`**: Optional Google service-account credentials.
 - **`options.credentials.email`**: The Google service-account email.
 - **`options.credentials.privateKey`**: The Google service-account private key.
 
@@ -1591,14 +1579,13 @@ Loads data from a Google Sheet into the table. This method uses the
 [journalism library](https://jsr.io/@nshiab/journalism). Refer to its
 documentation for more details.
 
-By default, authentication uses `GOOGLE_SERVICE_ACCOUNT_EMAIL` (for example,
-`"service-account@example.iam.gserviceaccount.com"`) with `GOOGLE_PRIVATE_KEY`
-(for example, `"-----BEGIN PRIVATE KEY-----\n..."`). Alternatively, set
-`GOOGLE_APPLICATION_CREDENTIALS` to a service-account JSON path (for example,
-`"./service-account.json"`). Use `options.apiEmailEnvVar` and
-`options.apiKeyEnvVar` to read the email and private key from custom variable
-names instead. The download is queued and runs in chain order at the next
-awaited observer or `run()` call.
+Environment variables are named configuration values supplied to the running
+process. By default, this method reads `GOOGLE_SERVICE_ACCOUNT_EMAIL` (for
+example, `"service-account@example.iam.gserviceaccount.com"`) with
+`GOOGLE_PRIVATE_KEY` (for example, `"-----BEGIN PRIVATE KEY-----\n..."`).
+Alternatively, set `GOOGLE_APPLICATION_CREDENTIALS` to a service-account JSON
+path (for example, `"./service-account.json"`). The download is queued and runs
+in chain order at the next awaited observer or `run()` call.
 
 ##### Signature
 
@@ -1614,12 +1601,12 @@ loadSheet(sheetUrl: string, options?: { skip?: number; apiEmailEnvVar?: string; 
 - **`options.skip`**: The number of rows to skip from the top of the sheet
   before reading data. Useful when the sheet contains metadata or headers that
   should not be included in the data.
-- **`options.apiEmailEnvVar`**: The name of the environment variable that stores
-  your Google service-account email (for example, `"MY_GOOGLE_EMAIL"`). Defaults
-  to `"GOOGLE_SERVICE_ACCOUNT_EMAIL"`.
-- **`options.apiKeyEnvVar`**: The name of the environment variable that stores
-  your Google service-account private key (for example,
-  `"MY_GOOGLE_PRIVATE_KEY"`). Defaults to `"GOOGLE_PRIVATE_KEY"`.
+- **`options.apiEmailEnvVar`**: A custom environment-variable name from which to
+  read the Google service-account email. Defaults to
+  `"GOOGLE_SERVICE_ACCOUNT_EMAIL"`.
+- **`options.apiKeyEnvVar`**: A custom environment-variable name from which to
+  read the Google service-account private key. Defaults to
+  `"GOOGLE_PRIVATE_KEY"`.
 
 ##### Returns
 
@@ -1651,9 +1638,9 @@ const sheetData = await table
 
 Writes the table data as CSV to a Datawrapper chart or table.
 
-Authentication uses the API key in `DATAWRAPPER_KEY` (for example,
-`"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a
-custom environment variable instead.
+Environment variables are named configuration values supplied to the running
+process. By default, this method reads the API key from `DATAWRAPPER_KEY` (for
+example, `"your-datawrapper-api-key"`).
 
 ##### Signature
 
@@ -1666,9 +1653,8 @@ async toDatawrapper(chartId: string, options?: { apiKeyEnvVar?: string; note?: s
 - **`chartId`**: The unique ID of the Datawrapper chart or table to update. This
   ID can be found in the Datawrapper URL or dashboard.
 - **`options`**: An optional object with configuration options:
-- **`options.apiKeyEnvVar`**: The name of the environment variable that stores
-  your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to
-  `"DATAWRAPPER_KEY"`.
+- **`options.apiKeyEnvVar`**: A custom environment-variable name from which to
+  read the Datawrapper API key. Defaults to `"DATAWRAPPER_KEY"`.
 - **`options.note`**: A string to update the chart's notes field with (e.g., a
   last-updated timestamp).
 - **`options.republish`**: If `true`, republishes the chart after updating the
@@ -1702,9 +1688,9 @@ await table.toDatawrapper("myChartId", {
 
 Loads data from a Datawrapper chart or table into the table.
 
-Authentication uses the API key in `DATAWRAPPER_KEY` (for example,
-`"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a
-custom environment variable instead. The download is queued and runs in chain
+Environment variables are named configuration values supplied to the running
+process. By default, this method reads the API key from `DATAWRAPPER_KEY` (for
+example, `"your-datawrapper-api-key"`). The download is queued and runs in chain
 order at the next awaited observer or `run()` call.
 
 ##### Signature
@@ -1718,9 +1704,8 @@ loadDatawrapper(chartId: string, options?: { apiKeyEnvVar?: string }): this;
 - **`chartId`**: The unique ID of the Datawrapper chart or table. This ID can be
   found in the Datawrapper URL or dashboard.
 - **`options`**: An optional object with configuration options:
-- **`options.apiKeyEnvVar`**: The name of the environment variable that stores
-  your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to
-  `"DATAWRAPPER_KEY"`.
+- **`options.apiKeyEnvVar`**: A custom environment-variable name from which to
+  read the Datawrapper API key. Defaults to `"DATAWRAPPER_KEY"`.
 
 ##### Returns
 
@@ -1741,9 +1726,9 @@ const chartData = await sdb
 
 Writes the table's geospatial data as GeoJSON to a Datawrapper map.
 
-Authentication uses the API key in `DATAWRAPPER_KEY` (for example,
-`"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a
-custom environment variable instead.
+Environment variables are named configuration values supplied to the running
+process. By default, this method reads the API key from `DATAWRAPPER_KEY` (for
+example, `"your-datawrapper-api-key"`).
 
 ##### Signature
 
@@ -1756,9 +1741,8 @@ async toGeoDatawrapper(chartId: string, options?: { apiKeyEnvVar?: string; colum
 - **`chartId`**: The unique ID of the Datawrapper map to update. This ID can be
   found in the Datawrapper URL or dashboard.
 - **`options`**: An optional object with configuration options:
-- **`options.apiKeyEnvVar`**: The name of the environment variable that stores
-  your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to
-  `"DATAWRAPPER_KEY"`.
+- **`options.apiKeyEnvVar`**: A custom environment-variable name from which to
+  read the Datawrapper API key. Defaults to `"DATAWRAPPER_KEY"`.
 - **`options.column`**: The name of the geometry column to use. If omitted, the
   method will automatically attempt to find a geometry column.
 - **`options.note`**: A string to update the map's notes field with.
@@ -1793,9 +1777,9 @@ await table.toGeoDatawrapper("myMapId", {
 
 Loads geospatial data from a Datawrapper map into the table.
 
-Authentication uses the API key in `DATAWRAPPER_KEY` (for example,
-`"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a
-custom environment variable instead.
+Environment variables are named configuration values supplied to the running
+process. By default, this method reads the API key from `DATAWRAPPER_KEY` (for
+example, `"your-datawrapper-api-key"`).
 
 The data is temporarily written to `.sda-cache/tmp/dataviz/<uuid>.geojson` and
 removed after loading. Remember to add `.sda-cache` to your `.gitignore`. The
@@ -1813,9 +1797,8 @@ loadGeoDatawrapper(chartId: string, options?: { apiKeyEnvVar?: string }): this;
 - **`chartId`**: The unique ID of the Datawrapper map. This ID can be found in
   the Datawrapper URL or dashboard.
 - **`options`**: An optional object with configuration options:
-- **`options.apiKeyEnvVar`**: The name of the environment variable that stores
-  your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to
-  `"DATAWRAPPER_KEY"`.
+- **`options.apiKeyEnvVar`**: A custom environment-variable name from which to
+  read the Datawrapper API key. Defaults to `"DATAWRAPPER_KEY"`.
 
 ##### Returns
 

--- a/llm.md
+++ b/llm.md
@@ -600,6 +600,7 @@ const employees = await sdb
   .newTable("employees")
   .loadData("./employees.csv")
   .log();
+
 // Close the database connection and clean up resources
 await sdb.close();
 ```

--- a/llm.md
+++ b/llm.md
@@ -669,9 +669,7 @@ This method supports Gemini, Vertex AI, and Ollama. When the corresponding
 `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY`
 (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
 `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
-Explicit `generation` options override the corresponding environment variables;
-all other fields match the selected `askGemini` or `askOllama` function from
-journalism-ai.
+Explicit `generation` options override the corresponding environment variables.
 
 For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set
 `AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
@@ -719,8 +717,8 @@ aiRowByRow(column: string, newColumn: string | string[], prompt: string, options
 - **`options.logProgress`**: If `true`, logs request-pool progress. Defaults to
   `false`.
 - **`options.generation`**: Gemini or Ollama generation configuration. Set
-  `provider` explicitly or omit it to use environment selection; all other
-  fields match the selected journalism-ai function.
+  `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here
+  override the corresponding environment variables.
 - **`options.test`**: A function to validate the returned data. If it throws an
   error, the request will be retried (if `retry` is set). Defaults to
   `undefined`.
@@ -842,8 +840,7 @@ corresponding `embeddings` options are omitted, configuration comes from
 `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example,
 `"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
 `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
-Explicit `embeddings` options override the corresponding environment variables;
-all other fields match `getEmbedding` from journalism-ai.
+Explicit `embeddings` options override the corresponding environment variables.
 
 For Ollama, set `AI_EMBEDDINGS_PROVIDER=ollama`, ensure Ollama is running, and
 set `AI_EMBEDDINGS_MODEL`, or pass `{ provider: "ollama", ... }` through
@@ -901,8 +898,8 @@ aiEmbeddings(column: string, newColumn: string, options?: { embeddings?: { provi
 - **`options.concurrency`**: The number of concurrent requests to send. Defaults
   to `1`.
 - **`options.embeddings`**: Gemini or Ollama embedding configuration. Set
-  `provider` explicitly or omit it to use environment selection; all other
-  fields match `getEmbedding` from journalism-ai.
+  `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values
+  provided here override the corresponding environment variables.
 - **`options.rateLimitPerMinute`**: The rate limit for AI requests in requests
   per minute. The method will wait between requests if necessary. Defaults to
   `undefined` (no limit).
@@ -954,15 +951,15 @@ content based on their embeddings. This method is useful for semantic search and
 text similarity tasks, computing cosine distance and sorting results by
 similarity.
 
-To create the query embedding, pass provider-specific options matching
-`getEmbedding` from journalism-ai or use environment variables. When the
-corresponding `embeddings` options are omitted, configuration comes from
-`AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`),
-`AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or
-`"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example,
-`"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
-`"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
-Explicit `embeddings` options override the corresponding environment variables.
+To create the query embedding, pass `embeddings` options directly or use
+environment variables. When the corresponding `embeddings` options are omitted,
+configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`;
+defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example,
+`"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either
+`AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for
+example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example,
+`"us-central1"`). Explicit `embeddings` options override the corresponding
+environment variables.
 
 Gemini, Vertex AI, and Ollama are supported. The selected provider and model
 must match those used to create the stored embedding column so the vectors share
@@ -1016,8 +1013,8 @@ aiVectorSimilarity(text: string, column: string, nbResults: number, options?: { 
   be stored. If not provided, the current table will be modified. Defaults to
   `undefined`.
 - **`options.embeddings`**: Gemini or Ollama embedding configuration. Set
-  `provider` explicitly or omit it to use environment selection; all other
-  fields match `getEmbedding` from journalism-ai.
+  `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values
+  provided here override the corresponding environment variables.
 - **`options.verbose`**: If `true`, logs additional debugging information.
   Defaults to `false`.
 
@@ -1093,8 +1090,7 @@ corresponding `embeddings` options are omitted, configuration comes from
 `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example,
 `"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
 `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
-Explicit `embeddings` options override the corresponding environment variables;
-all other fields match `getEmbedding` from journalism-ai.
+Explicit `embeddings` options override the corresponding environment variables.
 
 The selected embedding provider is used for both stored row embeddings and the
 query embedding.
@@ -1123,8 +1119,8 @@ hybridSearch(query: string, idColumn: string, textColumn: string, nbResults: num
 - **`nbResults`**: The number of most similar rows to retrieve.
 - **`options`**: Configuration options for the hybrid search.
 - **`options.embeddings`**: Gemini or Ollama embedding configuration. Set
-  `provider` explicitly or omit it to use environment selection; all other
-  fields match `getEmbedding` from journalism-ai.
+  `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values
+  provided here override the corresponding environment variables.
 - **`options.verbose`**: If `true`, logs additional debugging information.
   Defaults to `false`.
 - **`options.createIndex`**: If `true`, creates an HNSW index when vector search
@@ -1246,7 +1242,7 @@ or `"gemma3:4b"`), while embeddings use `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or
 embeddings use either `AI_KEY` (for example, `"your-gemini-api-key"`) or both
 `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for
 example, `"us-central1"`). Explicit nested options override the corresponding
-environment variables; all remaining fields match journalism-ai.
+environment variables.
 
 For example, `generation.provider` can be `"gemini"` while `embeddings.provider`
 is `"ollama"`; the same mix can be selected through `AI_PROVIDER=gemini` and
@@ -1279,11 +1275,11 @@ async aiRAG(query: string, idColumn: string, textColumn: string, nbResults: numb
   context for the AI.
 - **`options`**: Configuration options for the RAG process.
 - **`options.generation`**: Gemini or Ollama generation configuration. Set
-  `provider` explicitly or omit it to use environment selection; all other
-  relevant fields match the selected journalism-ai function.
+  `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here
+  override the corresponding environment variables.
 - **`options.embeddings`**: Gemini or Ollama embedding configuration. Set
-  `provider` explicitly or omit it to use environment selection; all other
-  fields match `getEmbedding` from journalism-ai.
+  `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values
+  provided here override the corresponding environment variables.
 - **`options.verbose`**: If `true`, logs additional debugging information.
   Defaults to `false`.
 - **`options.includeThoughts`**: If `true`, includes the AI model's reasoning
@@ -1402,8 +1398,7 @@ This method supports Gemini, Vertex AI, and Ollama. When the corresponding
 `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY`
 (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example,
 `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`).
-Explicit `generation` options override the corresponding environment variables;
-all other relevant fields match `askGemini` or `askOllama` from journalism-ai.
+Explicit `generation` options override the corresponding environment variables.
 
 For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set
 `AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
@@ -1429,8 +1424,8 @@ aiQuery(prompt: string, options?: { extraInstructions?: string; generation?: { s
 - **`options.extraInstructions`**: Additional instructions to append to the
   prompt, providing more context or guidance for the AI.
 - **`options.generation`**: Gemini or Ollama generation configuration. Set
-  `provider` explicitly or omit it to use environment selection; all other
-  relevant fields match the selected journalism-ai function.
+  `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here
+  override the corresponding environment variables.
 - **`options.outputTable`**: The name of a new table where the results will be
   stored. If not provided, the current table will be replaced with the query
   results.

--- a/src/class/SimpleDB.ts
+++ b/src/class/SimpleDB.ts
@@ -21,6 +21,7 @@ import SimpleTable from "./SimpleTable.ts";
  *   .newTable("employees")
  *   .loadData("./employees.csv")
  *   .log();
+ *
  * // Close the database connection and clean up resources
  * await sdb.close();
  * ```

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -74,7 +74,7 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * This method automatically appends instructions to your prompt; set `verbose` to `true` to see the full prompt.
    *
-   * This method supports Gemini, Vertex AI, and Ollama. Set `generation.provider` explicitly, or omit it to use `AI_PROVIDER`. All other `generation` fields match the selected `askGemini` or `askOllama` function from journalism-ai. Model and credentials can also come from environment variables.
+   * This method supports Gemini, Vertex AI, and Ollama. When the corresponding `generation` options are omitted, configuration comes from `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `generation` options override the corresponding environment variables; all other fields match the selected `askGemini` or `askOllama` function from journalism-ai.
    *
    * For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set `AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
    *
@@ -156,6 +156,10 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * @example
    * ```ts
+   * // Set these environment variables before running:
+   * // AI_PROVIDER=gemini
+   * // AI_MODEL=gemini-3-flash-preview
+   * // AI_KEY=your-gemini-api-key
    * const cities = await sdb
    *   .newTable("cities")
    *   .loadArray([
@@ -304,7 +308,7 @@ export default class SimpleTable extends SimpleTableCore {
   /**
    * Generates embeddings for a specified text column and stores the results in a new column.
    *
-   * This method supports Gemini, Vertex AI, and Ollama embeddings. Set `embeddings.provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`; all other fields match `getEmbedding` from journalism-ai. Model and credentials can also come from environment variables.
+   * This method supports Gemini, Vertex AI, and Ollama embeddings. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables; all other fields match `getEmbedding` from journalism-ai.
    *
    * For Ollama, set `AI_EMBEDDINGS_PROVIDER=ollama`, ensure Ollama is running, and set `AI_EMBEDDINGS_MODEL`, or pass `{ provider: "ollama", ... }` through `embeddings`.
    *
@@ -336,6 +340,10 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * @example
    * ```ts
+   * // Set these environment variables before running:
+   * // AI_EMBEDDINGS_PROVIDER=gemini
+   * // AI_EMBEDDINGS_MODEL=gemini-embedding-001
+   * // AI_KEY=your-gemini-api-key
    * const food = await sdb
    *   .newTable("food")
    *   .loadArray([
@@ -347,10 +355,6 @@ export default class SimpleTable extends SimpleTableCore {
    *     { food: "tacos" },
    *   ])
    *   .aiEmbeddings("food", "embeddings", {
-   *     embeddings: {
-   *       provider: "gemini",
-   *       model: "gemini-embedding-001",
-   *     },
    *     rateLimitPerMinute: 15,
    *     createIndex: true,
    *     verbose: true,
@@ -446,7 +450,7 @@ export default class SimpleTable extends SimpleTableCore {
    * Creates an embedding from a specified text and returns the most similar text content based on their embeddings.
    * This method is useful for semantic search and text similarity tasks, computing cosine distance and sorting results by similarity.
    *
-   * To create the query embedding, omit `embeddings` to use environment variables or pass provider-specific options matching `getEmbedding` from journalism-ai.
+   * To create the query embedding, pass provider-specific options matching `getEmbedding` from journalism-ai or use environment variables. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables.
    *
    * Gemini, Vertex AI, and Ollama are supported. The selected provider and model must match those used to create the stored embedding column so the vectors share the same dimensions and embedding space.
    *
@@ -474,6 +478,10 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * @example
    * ```ts
+   * // Set these environment variables before running:
+   * // AI_EMBEDDINGS_PROVIDER=gemini
+   * // AI_EMBEDDINGS_MODEL=gemini-embedding-001
+   * // AI_KEY=your-gemini-api-key
    * const similarFood = await sdb
    *   .newTable("food")
    *   .loadArray([
@@ -484,18 +492,9 @@ export default class SimpleTable extends SimpleTableCore {
    *     { food: "salad" },
    *     { food: "tacos" },
    *   ])
-   *   .aiEmbeddings("food", "embeddings", {
-   *     embeddings: {
-   *       provider: "gemini",
-   *       model: "gemini-embedding-001",
-   *     },
-   *   })
+   *   .aiEmbeddings("food", "embeddings")
    *   .aiVectorSimilarity("italian food", "embeddings", 3, {
    *     createIndex: true,
-   *     embeddings: {
-   *       provider: "gemini",
-   *       model: "gemini-embedding-001",
-   *     },
    *     minSimilarity: 0.6,
    *     similarityColumn: "score",
    *   })
@@ -608,7 +607,7 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * Remove `.journalism-cache` and `.sda-cache` to clear existing cache entries. Remember to add both directories to your `.gitignore`.
    *
-   * This method supports Gemini, Vertex AI, and Ollama embeddings. Set `embeddings.provider` explicitly or omit it to use environment selection; all other fields match `getEmbedding` from journalism-ai.
+   * This method supports Gemini, Vertex AI, and Ollama embeddings. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables; all other fields match `getEmbedding` from journalism-ai.
    *
    * The selected embedding provider is used for both stored row embeddings and the query embedding.
    *
@@ -650,16 +649,16 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * @example
    * ```ts
+   * // Set these environment variables before running:
+   * // AI_EMBEDDINGS_PROVIDER=gemini
+   * // AI_EMBEDDINGS_MODEL=gemini-embedding-001
+   * // AI_KEY=your-gemini-api-key
    * // Load a dataset of recipes
    * const sdb = new SimpleDB();
    * const results = await sdb
    *   .newTable("recipes")
    *   .loadData("recipes.parquet")
    *   .hybridSearch("buttery pastry for breakfast", "Dish", "Recipe", 10, {
-   *     embeddings: {
-   *       provider: "gemini",
-   *       model: "gemini-embedding-001",
-   *     },
    *     verbose: true,
    *   })
    *   .log();
@@ -816,9 +815,9 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * Remove `.journalism-cache` and `.sda-cache` to clear existing cache entries. Remember to add both directories to your `.gitignore`.
    *
-   * Generation and embeddings are independently configurable. Set either nested `provider` explicitly or omit it to use that provider's environment selection; all remaining fields match journalism-ai.
+   * Generation and embeddings are independently configurable. When the corresponding options are omitted, generation uses `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`) and `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), while embeddings use `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`) and `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`). Gemini generation and embeddings use either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit nested options override the corresponding environment variables; all remaining fields match journalism-ai.
    *
-   * For example, `generation.provider` can be `"gemini"` while `embeddings.provider` is `"ollama"`. Environment-only mixed providers use `AI_PROVIDER` and `AI_EMBEDDINGS_PROVIDER`.
+   * For example, `generation.provider` can be `"gemini"` while `embeddings.provider` is `"ollama"`; the same mix can be selected through `AI_PROVIDER=gemini` and `AI_EMBEDDINGS_PROVIDER=ollama`.
    *
    * Ollama temperature defaults to 0. Gemini uses the provider's default temperature.
    *
@@ -860,6 +859,12 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * @example
    * ```ts
+   * // Set these environment variables before running:
+   * // AI_PROVIDER=gemini
+   * // AI_MODEL=gemini-3-flash-preview
+   * // AI_KEY=your-gemini-api-key
+   * // AI_EMBEDDINGS_PROVIDER=ollama
+   * // AI_EMBEDDINGS_MODEL=nomic-embed-text
    * // Load a dataset of recipes
    * const sdb = new SimpleDB();
    * const answer = await sdb
@@ -870,17 +875,7 @@ export default class SimpleTable extends SimpleTableCore {
    *     "Dish", // Column with unique IDs
    *     "Recipe", // Column with text to search
    *     10, // The 10 most relevant recipes passed to the LLM
-   *     {
-   *       generation: {
-   *         provider: "gemini",
-   *         model: "gemini-3-flash-preview",
-   *       },
-   *       embeddings: {
-   *         provider: "ollama",
-   *         model: "nomic-embed-text",
-   *       },
-   *       verbose: true, // Log debugging information and timings
-   *     },
+   *     { verbose: true }, // Log debugging information and timings
    *   );
    *
    * console.log(answer);
@@ -1111,7 +1106,7 @@ export default class SimpleTable extends SimpleTableCore {
    * Generates and executes a SQL query based on a prompt.
    * Additional instructions, such as column types, are automatically added to your prompt. Set `verbose` to `true` to see the full prompt.
    *
-   * This method supports Gemini, Vertex AI, and Ollama. Set `generation.provider` explicitly or omit it to use environment selection; all other relevant fields match `askGemini` or `askOllama` from journalism-ai.
+   * This method supports Gemini, Vertex AI, and Ollama. When the corresponding `generation` options are omitted, configuration comes from `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `generation` options override the corresponding environment variables; all other relevant fields match `askGemini` or `askOllama` from journalism-ai.
    *
    * For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set `AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
    *
@@ -1132,17 +1127,17 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * @example
    * ```ts
+   * // Set these environment variables before running:
+   * // AI_PROVIDER=gemini
+   * // AI_MODEL=gemini-3-flash-preview
+   * // AI_KEY=your-gemini-api-key
    * // The AI will generate a query that will be executed, and
    * // the result will replace the existing table.
    * // If run again, it will use the previous query from the cache.
    * // Don't forget to add .journalism-cache to your .gitignore file!
    * const averageSalaryByDepartment = await table
    *   .aiQuery("Give me the average salary by department", {
-   *       generation: {
-   *         provider: "gemini",
-   *         model: "gemini-3-flash-preview",
-   *       },
-   *       verbose: true,
+   *     verbose: true,
    *   })
    *   .log();
    * ```
@@ -1273,7 +1268,7 @@ export default class SimpleTable extends SimpleTableCore {
    * Writes the table data to a Google Sheet.
    * This method uses the `pushToSheet` function from the [journalism-google library](https://jsr.io/@nshiab/journalism-google). Refer to its documentation for more details.
    *
-   * By default, the selected tab is overwritten and values are written without Google Sheets interpretation. Authentication is handled via environment variables (GOOGLE_PRIVATE_KEY and GOOGLE_SERVICE_ACCOUNT_EMAIL). Alternatively, you can use GOOGLE_APPLICATION_CREDENTIALS pointing to a service account JSON file. For detailed setup instructions, refer to the node-google-spreadsheet authentication guide: https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication.
+   * By default, the selected tab is overwritten and values are written without Google Sheets interpretation. Authentication uses `GOOGLE_SERVICE_ACCOUNT_EMAIL` (for example, `"service-account@example.iam.gserviceaccount.com"`) with `GOOGLE_PRIVATE_KEY` (for example, `"-----BEGIN PRIVATE KEY-----\n..."`). Alternatively, set `GOOGLE_APPLICATION_CREDENTIALS` to a service-account JSON path (for example, `"./service-account.json"`). Explicit `options.credentials` override these environment variables. For detailed setup instructions, refer to the node-google-spreadsheet authentication guide: https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication.
    *
    * @param sheetUrl - A Google Sheets URL. It can point to a spreadsheet or a specific tab.
    * @param options - An optional object with configuration options:
@@ -1291,6 +1286,9 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * @example
    * ```ts
+   * // Set these environment variables before running:
+   * // GOOGLE_SERVICE_ACCOUNT_EMAIL=service-account@example.iam.gserviceaccount.com
+   * // GOOGLE_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\n...
    * // Load, transform, and write data to a Google Sheet
    * await sdb
    *   .newTable()
@@ -1374,19 +1372,22 @@ export default class SimpleTable extends SimpleTableCore {
    * Loads data from a Google Sheet into the table.
    * This method uses the `getSheetData` function from the [journalism library](https://jsr.io/@nshiab/journalism). Refer to its documentation for more details.
    *
-   * By default, authentication is handled via environment variables (GOOGLE_PRIVATE_KEY and GOOGLE_SERVICE_ACCOUNT_EMAIL). Alternatively, you can use GOOGLE_APPLICATION_CREDENTIALS pointing to a service account JSON file. For detailed setup instructions, refer to the node-google-spreadsheet authentication guide: https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication.
+   * By default, authentication uses `GOOGLE_SERVICE_ACCOUNT_EMAIL` (for example, `"service-account@example.iam.gserviceaccount.com"`) with `GOOGLE_PRIVATE_KEY` (for example, `"-----BEGIN PRIVATE KEY-----\n..."`). Alternatively, set `GOOGLE_APPLICATION_CREDENTIALS` to a service-account JSON path (for example, `"./service-account.json"`). Use `options.apiEmailEnvVar` and `options.apiKeyEnvVar` to read the email and private key from custom variable names instead.
    * The download is queued and runs in chain order at the next awaited observer or `run()` call.
    *
    * @param sheetUrl - The URL pointing to a specific Google Sheet (e.g., `"https://docs.google.com/spreadsheets/d/.../edit#gid=0"`).
    * @param options - An optional object with configuration options:
    * @param options.skip - The number of rows to skip from the top of the sheet before reading data. Useful when the sheet contains metadata or headers that should not be included in the data.
-   * @param options.apiEmailEnvVar - The name of the environment variable that stores your API email.
-   * @param options.apiKeyEnvVar - The name of the environment variable that stores your API key.
+   * @param options.apiEmailEnvVar - The name of the environment variable that stores your Google service-account email (for example, `"MY_GOOGLE_EMAIL"`). Defaults to `"GOOGLE_SERVICE_ACCOUNT_EMAIL"`.
+   * @param options.apiKeyEnvVar - The name of the environment variable that stores your Google service-account private key (for example, `"MY_GOOGLE_PRIVATE_KEY"`). Defaults to `"GOOGLE_PRIVATE_KEY"`.
    * @returns The table, so methods can be chained.
    * @category Loading Data
    *
    * @example
    * ```ts
+   * // Set these environment variables before running:
+   * // GOOGLE_SERVICE_ACCOUNT_EMAIL=service-account@example.iam.gserviceaccount.com
+   * // GOOGLE_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\n...
    * // Load data from a Google Sheet
    * const sheetData = await sdb
    *   .newTable("sheetData")
@@ -1418,7 +1419,7 @@ export default class SimpleTable extends SimpleTableCore {
   /**
    * Writes the table data as CSV to a Datawrapper chart or table.
    *
-   * Authentication is handled via an API key stored in the environment variable `DATAWRAPPER_KEY`, or a custom variable name via `options.apiKeyEnvVar`.
+   * Authentication uses the API key in `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a custom environment variable instead.
    *
    * @param chartId - The unique ID of the Datawrapper chart or table to update. This ID can be found in the Datawrapper URL or dashboard.
    * @param options - An optional object with configuration options:
@@ -1430,6 +1431,7 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * @example
    * ```ts
+   * // Set DATAWRAPPER_KEY=your-datawrapper-api-key before running.
    * // Load, transform, and send data to a Datawrapper chart
    * await sdb
    *   .newTable()
@@ -1461,7 +1463,7 @@ export default class SimpleTable extends SimpleTableCore {
   /**
    * Loads data from a Datawrapper chart or table into the table.
    *
-   * Authentication is handled via an API key stored in the environment variable `DATAWRAPPER_KEY`, or a custom variable name via `options.apiKeyEnvVar`.
+   * Authentication uses the API key in `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a custom environment variable instead.
    * The download is queued and runs in chain order at the next awaited observer or `run()` call.
    *
    * @param chartId - The unique ID of the Datawrapper chart or table. This ID can be found in the Datawrapper URL or dashboard.
@@ -1472,6 +1474,7 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * @example
    * ```ts
+   * // Set DATAWRAPPER_KEY=your-datawrapper-api-key before running.
    * // Load data from a Datawrapper chart
    * const chartData = await sdb
    *   .newTable("chartData")
@@ -1492,7 +1495,7 @@ export default class SimpleTable extends SimpleTableCore {
   /**
    * Writes the table's geospatial data as GeoJSON to a Datawrapper map.
    *
-   * Authentication is handled via an API key stored in the environment variable `DATAWRAPPER_KEY`, or a custom variable name via `options.apiKeyEnvVar`.
+   * Authentication uses the API key in `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a custom environment variable instead.
    *
    * @param chartId - The unique ID of the Datawrapper map to update. This ID can be found in the Datawrapper URL or dashboard.
    * @param options - An optional object with configuration options:
@@ -1505,6 +1508,7 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * @example
    * ```ts
+   * // Set DATAWRAPPER_KEY=your-datawrapper-api-key before running.
    * // Load, transform, and send geospatial data to a Datawrapper map
    * await sdb
    *   .newTable()
@@ -1537,7 +1541,7 @@ export default class SimpleTable extends SimpleTableCore {
   /**
    * Loads geospatial data from a Datawrapper map into the table.
    *
-   * Authentication is handled via an API key stored in the environment variable `DATAWRAPPER_KEY`, or a custom variable name via `options.apiKeyEnvVar`.
+   * Authentication uses the API key in `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a custom environment variable instead.
    *
    * The data is temporarily written to `.sda-cache/tmp/dataviz/<uuid>.geojson` and removed after loading. Remember to add `.sda-cache` to your `.gitignore`.
    * The download is queued and runs in chain order at the next awaited observer or `run()` call.
@@ -1550,6 +1554,7 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * @example
    * ```ts
+   * // Set DATAWRAPPER_KEY=your-datawrapper-api-key before running.
    * // Load geo data from a Datawrapper map
    * const mapData = await sdb
    *   .newTable("mapData")

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -74,9 +74,9 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * This method automatically appends instructions to your prompt; set `verbose` to `true` to see the full prompt.
    *
-   * This method supports Gemini, Vertex AI, and Ollama. When the corresponding `generation` options are omitted, configuration comes from `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `generation` options override the corresponding environment variables.
+   * This method supports Gemini, Vertex AI, and Ollama.
    *
-   * For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set `AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
+   * Environment variables are named configuration values supplied to the running process. By default, this method reads `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Values passed through `generation` override the corresponding environment values. When using Ollama, ensure it is running.
    *
    * To manage rate limits, use `batchSize` to process multiple rows per request and `rateLimitPerMinute` to pace requests across the worker pool. The `concurrency` option controls how many requests may run in parallel.
    *
@@ -98,7 +98,7 @@ export default class SimpleTable extends SimpleTableCore {
    * @param options.concurrency - The number of concurrent requests to send. Defaults to `1`.
    * @param options.errorColumn - The optional column where per-row error messages are stored. When omitted, a failed batch throws.
    * @param options.logProgress - If `true`, logs request-pool progress. Defaults to `false`.
-   * @param options.generation - Gemini or Ollama generation configuration. Set `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here override the corresponding environment variables.
+   * @param options.generation - Optional Gemini or Ollama generation configuration.
    * @param options.test - A function to validate the returned data. If it throws an error, the request will be retried (if `retry` is set). Defaults to `undefined`.
    * @param options.retry - The number of times to retry the request in case of failure. Defaults to `0`.
    * @param options.retryCheck - A function that receives an error and returns whether it should be retried. Defaults to `undefined`.
@@ -308,9 +308,9 @@ export default class SimpleTable extends SimpleTableCore {
   /**
    * Generates embeddings for a specified text column and stores the results in a new column.
    *
-   * This method supports Gemini, Vertex AI, and Ollama embeddings. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables.
+   * This method supports Gemini, Vertex AI, and Ollama embeddings.
    *
-   * For Ollama, set `AI_EMBEDDINGS_PROVIDER=ollama`, ensure Ollama is running, and set `AI_EMBEDDINGS_MODEL`, or pass `{ provider: "ollama", ... }` through `embeddings`.
+   * Environment variables are named configuration values supplied to the running process. By default, this method reads `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Values passed through `embeddings` override the corresponding environment values. When using Ollama, ensure it is running.
    *
    * To manage rate limits, use `rateLimitPerMinute` to introduce delays between requests. For higher rate limits (business/professional accounts), `concurrency` allows parallel requests.
    *
@@ -332,7 +332,7 @@ export default class SimpleTable extends SimpleTableCore {
    * @param options.efSearch - The number of candidate vertices to consider during search. Higher values result in more accurate searches but increase search time. Defaults to 64.
    * @param options.M - The maximum number of neighbors to keep for each vertex in the graph. Higher values result in more accurate indexes but increase build time and memory usage. Defaults to 16.
    * @param options.concurrency - The number of concurrent requests to send. Defaults to `1`.
-   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values provided here override the corresponding environment variables.
+   * @param options.embeddings - Optional Gemini or Ollama embedding configuration.
    * @param options.rateLimitPerMinute - The rate limit for AI requests in requests per minute. The method will wait between requests if necessary. Defaults to `undefined` (no limit).
    * @param options.verbose - If `true`, logs additional debugging information. Defaults to `false`.
    * @returns The table, so methods can be chained.
@@ -450,7 +450,7 @@ export default class SimpleTable extends SimpleTableCore {
    * Creates an embedding from a specified text and returns the most similar text content based on their embeddings.
    * This method is useful for semantic search and text similarity tasks, computing cosine distance and sorting results by similarity.
    *
-   * To create the query embedding, pass `embeddings` options directly or use environment variables. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables.
+   * Environment variables are named configuration values supplied to the running process. By default, this method reads `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Values passed through `embeddings` override the corresponding environment values.
    *
    * Gemini, Vertex AI, and Ollama are supported. The selected provider and model must match those used to create the stored embedding column so the vectors share the same dimensions and embedding space.
    *
@@ -471,7 +471,7 @@ export default class SimpleTable extends SimpleTableCore {
    * @param options.efSearch - The number of candidate vertices to consider during search. Higher values result in more accurate searches but increase search time. Defaults to 64.
    * @param options.M - The maximum number of neighbors to keep for each vertex in the graph. Higher values result in more accurate indexes but increase build time and memory usage. Defaults to 16.
    * @param options.outputTable - The name of the output table where the results will be stored. If not provided, the current table will be modified. Defaults to `undefined`.
-   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values provided here override the corresponding environment variables.
+   * @param options.embeddings - Optional Gemini or Ollama embedding configuration.
    * @param options.verbose - If `true`, logs additional debugging information. Defaults to `false`.
    * @returns The table that will contain the similarity results, so methods can be chained.
    * @category AI
@@ -607,7 +607,9 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * Remove `.journalism-cache` and `.sda-cache` to clear existing cache entries. Remember to add both directories to your `.gitignore`.
    *
-   * This method supports Gemini, Vertex AI, and Ollama embeddings. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables.
+   * This method supports Gemini, Vertex AI, and Ollama embeddings.
+   *
+   * Environment variables are named configuration values supplied to the running process. By default, this method reads `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Values passed through `embeddings` override the corresponding environment values.
    *
    * The selected embedding provider is used for both stored row embeddings and the query embedding.
    *
@@ -621,7 +623,7 @@ export default class SimpleTable extends SimpleTableCore {
    * @param textColumn - The name of the column containing the text content to search through.
    * @param nbResults - The number of most similar rows to retrieve.
    * @param options - Configuration options for the hybrid search.
-   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values provided here override the corresponding environment variables.
+   * @param options.embeddings - Optional Gemini or Ollama embedding configuration.
    * @param options.verbose - If `true`, logs additional debugging information. Defaults to `false`.
    * @param options.createIndex - If `true`, creates an HNSW index when vector search is enabled. The BM25 FTS index is managed automatically whenever BM25 search is enabled. Defaults to `false`.
    * @param options.efConstruction - The number of candidate vertices to consider during index construction. Higher values result in more accurate indexes but increase build time. Defaults to 128.
@@ -815,7 +817,9 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * Remove `.journalism-cache` and `.sda-cache` to clear existing cache entries. Remember to add both directories to your `.gitignore`.
    *
-   * Generation and embeddings are independently configurable. When the corresponding options are omitted, generation uses `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`) and `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), while embeddings use `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`) and `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`). Gemini generation and embeddings use either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit nested options override the corresponding environment variables.
+   * Generation and embeddings are independently configurable.
+   *
+   * Environment variables are named configuration values supplied to the running process. By default, generation reads `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`) and `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), while embeddings read `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`) and `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`). Gemini generation and embeddings also read either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Values passed through either option override its environment defaults.
    *
    * For example, `generation.provider` can be `"gemini"` while `embeddings.provider` is `"ollama"`; the same mix can be selected through `AI_PROVIDER=gemini` and `AI_EMBEDDINGS_PROVIDER=ollama`.
    *
@@ -830,8 +834,8 @@ export default class SimpleTable extends SimpleTableCore {
    * @param textColumn - The name of the column containing the text content to search through and use as context.
    * @param nbResults - The number of most similar rows to retrieve and use as context for the AI.
    * @param options - Configuration options for the RAG process.
-   * @param options.generation - Gemini or Ollama generation configuration. Set `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here override the corresponding environment variables.
-   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values provided here override the corresponding environment variables.
+   * @param options.generation - Optional Gemini or Ollama generation configuration.
+   * @param options.embeddings - Optional Gemini or Ollama embedding configuration.
    * @param options.verbose - If `true`, logs additional debugging information. Defaults to `false`.
    * @param options.includeThoughts - If `true`, includes the AI model's reasoning process in the logged output when using models that support extended thinking. Only relevant when used with thinking-capable models. Defaults to `false`.
    * @param options.metrics - An object to track cumulative metrics across multiple AI requests. Pass an object with totalCost, totalInputTokens, totalOutputTokens, and totalRequests properties (all initialized to 0). The function will update these values after each request. Note: totalCost is only calculated for Google GenAI models, not for Ollama.
@@ -1106,9 +1110,9 @@ export default class SimpleTable extends SimpleTableCore {
    * Generates and executes a SQL query based on a prompt.
    * Additional instructions, such as column types, are automatically added to your prompt. Set `verbose` to `true` to see the full prompt.
    *
-   * This method supports Gemini, Vertex AI, and Ollama. When the corresponding `generation` options are omitted, configuration comes from `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `generation` options override the corresponding environment variables.
+   * This method supports Gemini, Vertex AI, and Ollama.
    *
-   * For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set `AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
+   * Environment variables are named configuration values supplied to the running process. By default, this method reads `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Values passed through `generation` override the corresponding environment values. When using Ollama, ensure it is running.
    *
    * Ollama temperature defaults to 0, while Gemini uses the provider's default. Provider-specific controls live under `generation`.
    *
@@ -1118,7 +1122,7 @@ export default class SimpleTable extends SimpleTableCore {
    * @param prompt - The input string to guide the AI in generating the SQL query.
    * @param options - Configuration options for the AI request.
    * @param options.extraInstructions - Additional instructions to append to the prompt, providing more context or guidance for the AI.
-   * @param options.generation - Gemini or Ollama generation configuration. Set `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here override the corresponding environment variables.
+   * @param options.generation - Optional Gemini or Ollama generation configuration.
    * @param options.outputTable - The name of a new table where the results will be stored. If not provided, the current table will be replaced with the query results.
    * @param options.verbose - If `true`, logs additional debugging information, including the full prompt sent to the AI. Defaults to `false`.
    * @param options.includeThoughts - If `true`, includes the AI model's reasoning process in the logged output when using models that support extended thinking. Only relevant when used with thinking-capable models. Defaults to `false`.
@@ -1268,7 +1272,9 @@ export default class SimpleTable extends SimpleTableCore {
    * Writes the table data to a Google Sheet.
    * This method uses the `pushToSheet` function from the [journalism-google library](https://jsr.io/@nshiab/journalism-google). Refer to its documentation for more details.
    *
-   * By default, the selected tab is overwritten and values are written without Google Sheets interpretation. Authentication uses `GOOGLE_SERVICE_ACCOUNT_EMAIL` (for example, `"service-account@example.iam.gserviceaccount.com"`) with `GOOGLE_PRIVATE_KEY` (for example, `"-----BEGIN PRIVATE KEY-----\n..."`). Alternatively, set `GOOGLE_APPLICATION_CREDENTIALS` to a service-account JSON path (for example, `"./service-account.json"`). Explicit `options.credentials` override these environment variables. For detailed setup instructions, refer to the node-google-spreadsheet authentication guide: https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication.
+   * By default, the selected tab is overwritten and values are written without Google Sheets interpretation.
+   *
+   * Environment variables are named configuration values supplied to the running process. For authentication, this method reads `GOOGLE_SERVICE_ACCOUNT_EMAIL` (for example, `"service-account@example.iam.gserviceaccount.com"`) with `GOOGLE_PRIVATE_KEY` (for example, `"-----BEGIN PRIVATE KEY-----\n..."`). Alternatively, set `GOOGLE_APPLICATION_CREDENTIALS` to a service-account JSON path (for example, `"./service-account.json"`). Values passed through `options.credentials` override these environment values. For detailed setup instructions, refer to the node-google-spreadsheet authentication guide: https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication.
    *
    * @param sheetUrl - A Google Sheets URL. It can point to a spreadsheet or a specific tab.
    * @param options - An optional object with configuration options:
@@ -1278,7 +1284,7 @@ export default class SimpleTable extends SimpleTableCore {
    * @param options.prepend - Text to add above the header row in overwrite mode.
    * @param options.lastUpdate - If `true`, adds a UTC timestamp. Pass a Canadian time zone to use it for the timestamp. Available only in overwrite mode.
    * @param options.raw - If `true`, writes values without Google Sheets interpretation. Defaults to `true`.
-   * @param options.credentials - Explicit Google service-account credentials. These override credentials provided through environment variables or GOOGLE_APPLICATION_CREDENTIALS.
+   * @param options.credentials - Optional Google service-account credentials.
    * @param options.credentials.email - The Google service-account email.
    * @param options.credentials.privateKey - The Google service-account private key.
    * @returns A promise that resolves when the data has been written to the sheet.
@@ -1372,14 +1378,14 @@ export default class SimpleTable extends SimpleTableCore {
    * Loads data from a Google Sheet into the table.
    * This method uses the `getSheetData` function from the [journalism library](https://jsr.io/@nshiab/journalism). Refer to its documentation for more details.
    *
-   * By default, authentication uses `GOOGLE_SERVICE_ACCOUNT_EMAIL` (for example, `"service-account@example.iam.gserviceaccount.com"`) with `GOOGLE_PRIVATE_KEY` (for example, `"-----BEGIN PRIVATE KEY-----\n..."`). Alternatively, set `GOOGLE_APPLICATION_CREDENTIALS` to a service-account JSON path (for example, `"./service-account.json"`). Use `options.apiEmailEnvVar` and `options.apiKeyEnvVar` to read the email and private key from custom variable names instead.
+   * Environment variables are named configuration values supplied to the running process. By default, this method reads `GOOGLE_SERVICE_ACCOUNT_EMAIL` (for example, `"service-account@example.iam.gserviceaccount.com"`) with `GOOGLE_PRIVATE_KEY` (for example, `"-----BEGIN PRIVATE KEY-----\n..."`). Alternatively, set `GOOGLE_APPLICATION_CREDENTIALS` to a service-account JSON path (for example, `"./service-account.json"`).
    * The download is queued and runs in chain order at the next awaited observer or `run()` call.
    *
    * @param sheetUrl - The URL pointing to a specific Google Sheet (e.g., `"https://docs.google.com/spreadsheets/d/.../edit#gid=0"`).
    * @param options - An optional object with configuration options:
    * @param options.skip - The number of rows to skip from the top of the sheet before reading data. Useful when the sheet contains metadata or headers that should not be included in the data.
-   * @param options.apiEmailEnvVar - The name of the environment variable that stores your Google service-account email (for example, `"MY_GOOGLE_EMAIL"`). Defaults to `"GOOGLE_SERVICE_ACCOUNT_EMAIL"`.
-   * @param options.apiKeyEnvVar - The name of the environment variable that stores your Google service-account private key (for example, `"MY_GOOGLE_PRIVATE_KEY"`). Defaults to `"GOOGLE_PRIVATE_KEY"`.
+   * @param options.apiEmailEnvVar - A custom environment-variable name from which to read the Google service-account email. Defaults to `"GOOGLE_SERVICE_ACCOUNT_EMAIL"`.
+   * @param options.apiKeyEnvVar - A custom environment-variable name from which to read the Google service-account private key. Defaults to `"GOOGLE_PRIVATE_KEY"`.
    * @returns The table, so methods can be chained.
    * @category Loading Data
    *
@@ -1419,11 +1425,11 @@ export default class SimpleTable extends SimpleTableCore {
   /**
    * Writes the table data as CSV to a Datawrapper chart or table.
    *
-   * Authentication uses the API key in `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a custom environment variable instead.
+   * Environment variables are named configuration values supplied to the running process. By default, this method reads the API key from `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`).
    *
    * @param chartId - The unique ID of the Datawrapper chart or table to update. This ID can be found in the Datawrapper URL or dashboard.
    * @param options - An optional object with configuration options:
-   * @param options.apiKeyEnvVar - The name of the environment variable that stores your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to `"DATAWRAPPER_KEY"`.
+   * @param options.apiKeyEnvVar - A custom environment-variable name from which to read the Datawrapper API key. Defaults to `"DATAWRAPPER_KEY"`.
    * @param options.note - A string to update the chart's notes field with (e.g., a last-updated timestamp).
    * @param options.republish - If `true`, republishes the chart after updating the data. Defaults to `false`.
    * @returns A promise that resolves when the data has been sent to Datawrapper.
@@ -1463,12 +1469,12 @@ export default class SimpleTable extends SimpleTableCore {
   /**
    * Loads data from a Datawrapper chart or table into the table.
    *
-   * Authentication uses the API key in `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a custom environment variable instead.
+   * Environment variables are named configuration values supplied to the running process. By default, this method reads the API key from `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`).
    * The download is queued and runs in chain order at the next awaited observer or `run()` call.
    *
    * @param chartId - The unique ID of the Datawrapper chart or table. This ID can be found in the Datawrapper URL or dashboard.
    * @param options - An optional object with configuration options:
-   * @param options.apiKeyEnvVar - The name of the environment variable that stores your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to `"DATAWRAPPER_KEY"`.
+   * @param options.apiKeyEnvVar - A custom environment-variable name from which to read the Datawrapper API key. Defaults to `"DATAWRAPPER_KEY"`.
    * @returns The table, so methods can be chained.
    * @category Loading Data
    *
@@ -1495,11 +1501,11 @@ export default class SimpleTable extends SimpleTableCore {
   /**
    * Writes the table's geospatial data as GeoJSON to a Datawrapper map.
    *
-   * Authentication uses the API key in `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a custom environment variable instead.
+   * Environment variables are named configuration values supplied to the running process. By default, this method reads the API key from `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`).
    *
    * @param chartId - The unique ID of the Datawrapper map to update. This ID can be found in the Datawrapper URL or dashboard.
    * @param options - An optional object with configuration options:
-   * @param options.apiKeyEnvVar - The name of the environment variable that stores your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to `"DATAWRAPPER_KEY"`.
+   * @param options.apiKeyEnvVar - A custom environment-variable name from which to read the Datawrapper API key. Defaults to `"DATAWRAPPER_KEY"`.
    * @param options.column - The name of the geometry column to use. If omitted, the method will automatically attempt to find a geometry column.
    * @param options.note - A string to update the map's notes field with.
    * @param options.republish - If `true`, republishes the map after updating the data. Defaults to `false`.
@@ -1541,14 +1547,14 @@ export default class SimpleTable extends SimpleTableCore {
   /**
    * Loads geospatial data from a Datawrapper map into the table.
    *
-   * Authentication uses the API key in `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`). Set `options.apiKeyEnvVar` to read the key from a custom environment variable instead.
+   * Environment variables are named configuration values supplied to the running process. By default, this method reads the API key from `DATAWRAPPER_KEY` (for example, `"your-datawrapper-api-key"`).
    *
    * The data is temporarily written to `.sda-cache/tmp/dataviz/<uuid>.geojson` and removed after loading. Remember to add `.sda-cache` to your `.gitignore`.
    * The download is queued and runs in chain order at the next awaited observer or `run()` call.
    *
    * @param chartId - The unique ID of the Datawrapper map. This ID can be found in the Datawrapper URL or dashboard.
    * @param options - An optional object with configuration options:
-   * @param options.apiKeyEnvVar - The name of the environment variable that stores your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). Defaults to `"DATAWRAPPER_KEY"`.
+   * @param options.apiKeyEnvVar - A custom environment-variable name from which to read the Datawrapper API key. Defaults to `"DATAWRAPPER_KEY"`.
    * @returns The table, so methods can be chained.
    * @category Loading Data
    *

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -74,7 +74,7 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * This method automatically appends instructions to your prompt; set `verbose` to `true` to see the full prompt.
    *
-   * This method supports Gemini, Vertex AI, and Ollama. When the corresponding `generation` options are omitted, configuration comes from `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `generation` options override the corresponding environment variables; all other fields match the selected `askGemini` or `askOllama` function from journalism-ai.
+   * This method supports Gemini, Vertex AI, and Ollama. When the corresponding `generation` options are omitted, configuration comes from `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `generation` options override the corresponding environment variables.
    *
    * For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set `AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
    *
@@ -98,7 +98,7 @@ export default class SimpleTable extends SimpleTableCore {
    * @param options.concurrency - The number of concurrent requests to send. Defaults to `1`.
    * @param options.errorColumn - The optional column where per-row error messages are stored. When omitted, a failed batch throws.
    * @param options.logProgress - If `true`, logs request-pool progress. Defaults to `false`.
-   * @param options.generation - Gemini or Ollama generation configuration. Set `provider` explicitly or omit it to use environment selection; all other fields match the selected journalism-ai function.
+   * @param options.generation - Gemini or Ollama generation configuration. Set `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here override the corresponding environment variables.
    * @param options.test - A function to validate the returned data. If it throws an error, the request will be retried (if `retry` is set). Defaults to `undefined`.
    * @param options.retry - The number of times to retry the request in case of failure. Defaults to `0`.
    * @param options.retryCheck - A function that receives an error and returns whether it should be retried. Defaults to `undefined`.
@@ -308,7 +308,7 @@ export default class SimpleTable extends SimpleTableCore {
   /**
    * Generates embeddings for a specified text column and stores the results in a new column.
    *
-   * This method supports Gemini, Vertex AI, and Ollama embeddings. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables; all other fields match `getEmbedding` from journalism-ai.
+   * This method supports Gemini, Vertex AI, and Ollama embeddings. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables.
    *
    * For Ollama, set `AI_EMBEDDINGS_PROVIDER=ollama`, ensure Ollama is running, and set `AI_EMBEDDINGS_MODEL`, or pass `{ provider: "ollama", ... }` through `embeddings`.
    *
@@ -332,7 +332,7 @@ export default class SimpleTable extends SimpleTableCore {
    * @param options.efSearch - The number of candidate vertices to consider during search. Higher values result in more accurate searches but increase search time. Defaults to 64.
    * @param options.M - The maximum number of neighbors to keep for each vertex in the graph. Higher values result in more accurate indexes but increase build time and memory usage. Defaults to 16.
    * @param options.concurrency - The number of concurrent requests to send. Defaults to `1`.
-   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use environment selection; all other fields match `getEmbedding` from journalism-ai.
+   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values provided here override the corresponding environment variables.
    * @param options.rateLimitPerMinute - The rate limit for AI requests in requests per minute. The method will wait between requests if necessary. Defaults to `undefined` (no limit).
    * @param options.verbose - If `true`, logs additional debugging information. Defaults to `false`.
    * @returns The table, so methods can be chained.
@@ -450,7 +450,7 @@ export default class SimpleTable extends SimpleTableCore {
    * Creates an embedding from a specified text and returns the most similar text content based on their embeddings.
    * This method is useful for semantic search and text similarity tasks, computing cosine distance and sorting results by similarity.
    *
-   * To create the query embedding, pass provider-specific options matching `getEmbedding` from journalism-ai or use environment variables. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables.
+   * To create the query embedding, pass `embeddings` options directly or use environment variables. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables.
    *
    * Gemini, Vertex AI, and Ollama are supported. The selected provider and model must match those used to create the stored embedding column so the vectors share the same dimensions and embedding space.
    *
@@ -471,7 +471,7 @@ export default class SimpleTable extends SimpleTableCore {
    * @param options.efSearch - The number of candidate vertices to consider during search. Higher values result in more accurate searches but increase search time. Defaults to 64.
    * @param options.M - The maximum number of neighbors to keep for each vertex in the graph. Higher values result in more accurate indexes but increase build time and memory usage. Defaults to 16.
    * @param options.outputTable - The name of the output table where the results will be stored. If not provided, the current table will be modified. Defaults to `undefined`.
-   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use environment selection; all other fields match `getEmbedding` from journalism-ai.
+   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values provided here override the corresponding environment variables.
    * @param options.verbose - If `true`, logs additional debugging information. Defaults to `false`.
    * @returns The table that will contain the similarity results, so methods can be chained.
    * @category AI
@@ -607,7 +607,7 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * Remove `.journalism-cache` and `.sda-cache` to clear existing cache entries. Remember to add both directories to your `.gitignore`.
    *
-   * This method supports Gemini, Vertex AI, and Ollama embeddings. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables; all other fields match `getEmbedding` from journalism-ai.
+   * This method supports Gemini, Vertex AI, and Ollama embeddings. When the corresponding `embeddings` options are omitted, configuration comes from `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `embeddings` options override the corresponding environment variables.
    *
    * The selected embedding provider is used for both stored row embeddings and the query embedding.
    *
@@ -621,7 +621,7 @@ export default class SimpleTable extends SimpleTableCore {
    * @param textColumn - The name of the column containing the text content to search through.
    * @param nbResults - The number of most similar rows to retrieve.
    * @param options - Configuration options for the hybrid search.
-   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use environment selection; all other fields match `getEmbedding` from journalism-ai.
+   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values provided here override the corresponding environment variables.
    * @param options.verbose - If `true`, logs additional debugging information. Defaults to `false`.
    * @param options.createIndex - If `true`, creates an HNSW index when vector search is enabled. The BM25 FTS index is managed automatically whenever BM25 search is enabled. Defaults to `false`.
    * @param options.efConstruction - The number of candidate vertices to consider during index construction. Higher values result in more accurate indexes but increase build time. Defaults to 128.
@@ -815,7 +815,7 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * Remove `.journalism-cache` and `.sda-cache` to clear existing cache entries. Remember to add both directories to your `.gitignore`.
    *
-   * Generation and embeddings are independently configurable. When the corresponding options are omitted, generation uses `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`) and `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), while embeddings use `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`) and `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`). Gemini generation and embeddings use either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit nested options override the corresponding environment variables; all remaining fields match journalism-ai.
+   * Generation and embeddings are independently configurable. When the corresponding options are omitted, generation uses `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`) and `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), while embeddings use `AI_EMBEDDINGS_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`) and `AI_EMBEDDINGS_MODEL` (for example, `"gemini-embedding-001"` or `"nomic-embed-text"`). Gemini generation and embeddings use either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit nested options override the corresponding environment variables.
    *
    * For example, `generation.provider` can be `"gemini"` while `embeddings.provider` is `"ollama"`; the same mix can be selected through `AI_PROVIDER=gemini` and `AI_EMBEDDINGS_PROVIDER=ollama`.
    *
@@ -830,8 +830,8 @@ export default class SimpleTable extends SimpleTableCore {
    * @param textColumn - The name of the column containing the text content to search through and use as context.
    * @param nbResults - The number of most similar rows to retrieve and use as context for the AI.
    * @param options - Configuration options for the RAG process.
-   * @param options.generation - Gemini or Ollama generation configuration. Set `provider` explicitly or omit it to use environment selection; all other relevant fields match the selected journalism-ai function.
-   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use environment selection; all other fields match `getEmbedding` from journalism-ai.
+   * @param options.generation - Gemini or Ollama generation configuration. Set `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here override the corresponding environment variables.
+   * @param options.embeddings - Gemini or Ollama embedding configuration. Set `provider` explicitly or omit it to use `AI_EMBEDDINGS_PROVIDER`. Values provided here override the corresponding environment variables.
    * @param options.verbose - If `true`, logs additional debugging information. Defaults to `false`.
    * @param options.includeThoughts - If `true`, includes the AI model's reasoning process in the logged output when using models that support extended thinking. Only relevant when used with thinking-capable models. Defaults to `false`.
    * @param options.metrics - An object to track cumulative metrics across multiple AI requests. Pass an object with totalCost, totalInputTokens, totalOutputTokens, and totalRequests properties (all initialized to 0). The function will update these values after each request. Note: totalCost is only calculated for Google GenAI models, not for Ollama.
@@ -1106,7 +1106,7 @@ export default class SimpleTable extends SimpleTableCore {
    * Generates and executes a SQL query based on a prompt.
    * Additional instructions, such as column types, are automatically added to your prompt. Set `verbose` to `true` to see the full prompt.
    *
-   * This method supports Gemini, Vertex AI, and Ollama. When the corresponding `generation` options are omitted, configuration comes from `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `generation` options override the corresponding environment variables; all other relevant fields match `askGemini` or `askOllama` from journalism-ai.
+   * This method supports Gemini, Vertex AI, and Ollama. When the corresponding `generation` options are omitted, configuration comes from `AI_PROVIDER` (`"gemini"` or `"ollama"`; defaults to `"gemini"`), `AI_MODEL` (for example, `"gemini-3-flash-preview"` or `"gemma3:4b"`), and, for Gemini, either `AI_KEY` (for example, `"your-gemini-api-key"`) or both `AI_PROJECT` (for example, `"my-google-cloud-project"`) and `AI_LOCATION` (for example, `"us-central1"`). Explicit `generation` options override the corresponding environment variables.
    *
    * For Ollama, set `AI_PROVIDER=ollama`, ensure Ollama is running, and set `AI_MODEL`, or pass `{ provider: "ollama", ... }` through `generation`.
    *
@@ -1118,7 +1118,7 @@ export default class SimpleTable extends SimpleTableCore {
    * @param prompt - The input string to guide the AI in generating the SQL query.
    * @param options - Configuration options for the AI request.
    * @param options.extraInstructions - Additional instructions to append to the prompt, providing more context or guidance for the AI.
-   * @param options.generation - Gemini or Ollama generation configuration. Set `provider` explicitly or omit it to use environment selection; all other relevant fields match the selected journalism-ai function.
+   * @param options.generation - Gemini or Ollama generation configuration. Set `provider` explicitly or omit it to use `AI_PROVIDER`. Values provided here override the corresponding environment variables.
    * @param options.outputTable - The name of a new table where the results will be stored. If not provided, the current table will be replaced with the query results.
    * @param options.verbose - If `true`, logs additional debugging information, including the full prompt sent to the AI. Defaults to `false`.
    * @param options.includeThoughts - If `true`, includes the AI model's reasoning process in the logged output when using models that support extended thinking. Only relevant when used with thinking-capable models. Defaults to `false`.


### PR DESCRIPTION
Closes #1238

## Summary

- document the exact AI, Google Sheets, and Datawrapper environment variables in public JSDoc, including safe example values and method-option precedence
- update public method examples with environment configuration comments
- add copyable README setup for Gemini API, Vertex AI, and Ollama
- enable verbose output in AI README examples
- add direct Google Sheets and Datawrapper export examples with the required environment configuration
- reuse named table variables in chained README examples to avoid unused-variable warnings
- normalize spacing before database close calls in README examples
- regenerate `llm.md` from the updated JSDoc

## Validation

- `deno task all-tests`
- 110 Deno tests passed
- Node and Bun ESM/CommonJS smoke tests passed
- npm publish dry-run and package checks passed

The validation command reports existing non-fatal dependency type-resolution warnings from `@google/genai` / `@types/node`.