### PR TITLE
Add Google Cloud Storage table methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,23 +20,24 @@ SDA is split into two packages:
 
 - **`simple-data-analysis`** (this package) extends the core with additional
   features: AI methods (row-by-row processing, embeddings, vector similarity,
-  hybrid search, RAG, natural language queries), Google Sheets integration, and
-  charting/dataviz methods. These features are built respectively on the
-  [`journalism-ai`](https://jsr.io/@nshiab/journalism-ai),
+  hybrid search, RAG, natural language queries), Google Cloud Storage and Google
+  Sheets integrations, and charting/dataviz methods. These features are built
+  respectively on the [`journalism-ai`](https://jsr.io/@nshiab/journalism-ai),
   [`journalism-google`](https://jsr.io/@nshiab/journalism-google), and
   [`journalism-dataviz`](https://jsr.io/@nshiab/journalism-dataviz) libraries.
 
 Most users will want this package (`simple-data-analysis`), which includes all
 of the core functionality plus the extended features.
 
-AI, Google Sheets, and charting dependencies load only when those operations
-run. If you only use core methods, you don't pay their startup cost.
+AI, Google, and charting dependencies load only when those operations run. If
+you only use core methods, you don't pay their startup cost.
 
 > [!NOTE]
 > SDA's `SimpleDB` and `SimpleTable` inherit all core methods, but JSR currently
 > omits inherited methods from their documentation because of an
-> [upstream limitation](https://github.com/jsr-io/jsr/issues/747). For those
-> methods, see the core
+> [upstream limitation](https://github.com/jsr-io/jsr/issues/747). For a
+> complete reference combining Core and SDA, see [`llm.md`](./llm.md). You can
+> also consult the core
 > [`SimpleDB` reference](https://jsr.io/@nshiab/simple-data-analysis-core/doc/~/SimpleDB)
 > and
 > [`SimpleTable` reference](https://jsr.io/@nshiab/simple-data-analysis-core/doc/~/SimpleTable).
@@ -159,16 +160,9 @@ methods are synchronous and chainable; async observer methods such as
 `getData()`, `log()`, and `writeData()` flush the queue before producing their
 result. This means only the final observer needs to be awaited.
 
-Methods that load or transform data—including `aiRowByRow()`, `aiEmbeddings()`,
-`aiVectorSimilarity()`, `hybridSearch()`, `aiQuery()`, `loadSheet()`,
-`loadDatawrapper()`, and `loadGeoDatawrapper()`—are also synchronous builders.
-Their external work runs when an observer executes the queue. Await a final
-observer or call `.run()` to execute a chain without reading or exporting its
-result.
-
-Methods that return an answer or export data, such as `aiRAG()`, `toSheet()`,
-`toDatawrapper()`, `toGeoDatawrapper()`, `writeChart()`, and `writeMap()`,
-remain asynchronous and must be awaited.
+Methods that return an answer or export data, such as `aiRAG()`, `toBucket()`,
+`toSheet()`, `toDatawrapper()`, `toGeoDatawrapper()`, `writeChart()`, and
+`writeMap()`, remain asynchronous and must be awaited.
 
 The syntax and the available methods were inspired by
 [Pandas](https://github.com/pandas-dev/pandas) (Python) and the
@@ -470,6 +464,50 @@ await sdb.close();
 
 ![Map showing the wildfires in Canada in 2023.](./assets/map.png)
 
+### Google Cloud Storage
+
+The
+[`toBucket`](https://jsr.io/@nshiab/simple-data-analysis/doc/~/SimpleTable.prototype.toBucket)
+method writes a table to a temporary file and uploads it to Google Cloud
+Storage. The
+[`loadBucket`](https://jsr.io/@nshiab/simple-data-analysis/doc/~/SimpleTable.prototype.loadBucket)
+method downloads and loads an object in chain order.
+
+Set the project and bucket in `.env`. Authentication uses Google Application
+Default Credentials. If ADC should load credentials from a specific JSON file,
+also set `GOOGLE_APPLICATION_CREDENTIALS` to that file's path:
+
+```dotenv
+BUCKET_PROJECT=my-google-cloud-project
+BUCKET_NAME=my-storage-bucket
+# Optional: load credentials from a specific JSON file.
+GOOGLE_APPLICATION_CREDENTIALS=./service-account.json
+```
+
+Load a table from one object, transform it, and upload the result as another
+object:
+
+```ts
+import { SimpleDB } from "@nshiab/simple-data-analysis";
+
+const sdb = new SimpleDB();
+
+const temperatures = await sdb
+  .newTable("temperatures")
+  .loadBucket("inputs/temperatures.parquet")
+  .filter("temperature > 30")
+  .log();
+
+const uri = await temperatures.toBucket(
+  "outputs/hotTemperatures.parquet",
+  { overwrite: true },
+);
+
+console.log(uri); // gs://my-storage-bucket/outputs/hotTemperatures.parquet
+
+await sdb.close();
+```
+
 ### Google Sheets
 
 The
@@ -489,11 +527,33 @@ JSON file:
 GOOGLE_APPLICATION_CREDENTIALS=./service-account.json
 ```
 
-Share the destination spreadsheet with the service-account email before running
-the example. The `loadSheet()` method uses the same environment variables.
+Share the spreadsheet with the service-account email before running the
+examples.
+
+#### Load from a sheet
+
+Use `loadSheet()` to load and transform data from a Google Sheet tab:
 
 ```ts
-// Uses Google service-account credentials from .env.
+import { SimpleDB } from "@nshiab/simple-data-analysis";
+
+const sdb = new SimpleDB();
+
+await sdb
+  .newTable("temperatures")
+  .loadSheet("https://docs.google.com/spreadsheets/d/.../edit#gid=0")
+  .filter("temperature > 30")
+  .selectColumns(["station", "time", "temperature"])
+  .log();
+
+await sdb.close();
+```
+
+#### Write to a sheet
+
+Use `toSheet()` to write a table to a Google Sheet tab:
+
+```ts
 import { SimpleDB } from "@nshiab/simple-data-analysis";
 
 const sdb = new SimpleDB();

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@nshiab/simple-data-analysis",
   "version": "6.0.1",
-  "description": "Fast DuckDB-powered TypeScript library for tabular, geospatial, vector, AI, Google Sheets, and data visualization workflows on Deno, Node.js, and Bun.",
+  "description": "Fast DuckDB-powered TypeScript library for tabular, geospatial, vector, AI, Google Cloud Storage, Google Sheets, and data visualization workflows on Deno, Node.js, and Bun.",
   "keywords": [
     "data-analysis",
     "typescript",
@@ -15,6 +15,7 @@
     "vector-search",
     "rag",
     "data-visualization",
+    "google-cloud-storage",
     "google-sheets",
     "deno",
     "nodejs",

--- a/llm.md
+++ b/llm.md
@@ -1473,6 +1473,123 @@ const averageSalaryByDepartment = await table
   .log();
 ```
 
+#### `toBucket`
+
+Writes the table to a file and uploads it to a Google Cloud Storage bucket.
+Supported destinations are `.csv`, `.csv.gz`, `.json`, `.json.gz`, `.parquet`,
+`.geojson`, `.geoparquet`, and `.shp.zip`.
+
+This method uses the `toBucket` function from the
+[journalism-google library](https://jsr.io/@nshiab/journalism-google). Set
+`BUCKET_PROJECT` and `BUCKET_NAME` in your `.env` file, or pass `project` and
+`bucket`. Authentication uses Google Application Default Credentials. To load
+credentials from a specific JSON file, set `GOOGLE_APPLICATION_CREDENTIALS` in
+your `.env` file to that file's path.
+
+##### Signature
+
+```typescript
+async toBucket(destination: string, options?: { project?: string; bucket?: string; overwrite?: boolean; skip?: boolean; metadata?: unknown }): Promise<string>;
+```
+
+##### Parameters
+
+- **`destination`**: The path and filename for the object within the bucket.
+- **`options`**: Upload options.
+- **`options.project`**: The Google Cloud project ID. Defaults to
+  `BUCKET_PROJECT`.
+- **`options.bucket`**: The Google Cloud Storage bucket name. Defaults to
+  `BUCKET_NAME`.
+- **`options.overwrite`**: If `true`, replaces an existing object. Cannot be
+  combined with `skip`. Defaults to `false`.
+- **`options.skip`**: If `true`, skips the upload when the object already
+  exists. Cannot be combined with `overwrite`. Defaults to `false`.
+- **`options.metadata`**: Metadata passed to `journalism-google` for the
+  uploaded object.
+
+##### Returns
+
+The `gs://` URI of the uploaded object.
+
+##### Examples
+
+```ts
+// Set BUCKET_PROJECT and BUCKET_NAME in .env, and configure Google Application Default Credentials.
+const uri = await sdb
+  .newTable("results")
+  .loadData("results.csv")
+  .selectColumns(["name", "value"])
+  .toBucket("exports/results.parquet", { overwrite: true });
+console.log(uri); // gs://my-bucket/exports/results.parquet
+```
+
+```ts
+// Export a geometry table as one zipped Shapefile object.
+await sdb
+  .newTable("districts")
+  .loadGeoData("districts.geojson")
+  .toBucket("maps/districts.shp.zip", {
+    project: "my-project",
+    bucket: "my-bucket",
+  });
+```
+
+#### `loadBucket`
+
+Downloads a file from Google Cloud Storage and loads it into the table.
+Supported sources are `.csv`, `.csv.gz`, `.json`, `.json.gz`, `.parquet`,
+`.geojson`, `.geoparquet`, and `.shp.zip`.
+
+This method uses the `downloadFromBucket` function from the
+[journalism-google library](https://jsr.io/@nshiab/journalism-google). Set
+`BUCKET_PROJECT` and `BUCKET_NAME` in your `.env` file, or pass `project` and
+`bucket`. Authentication uses Google Application Default Credentials. To load
+credentials from a specific JSON file, set `GOOGLE_APPLICATION_CREDENTIALS` in
+your `.env` file to that file's path.
+
+The download and load are queued and run in chain order at the next awaited
+observer or `run()` call.
+
+##### Signature
+
+```typescript
+loadBucket(source: string, options?: { project?: string; bucket?: string }): this;
+```
+
+##### Parameters
+
+- **`source`**: The path and filename of the object within the bucket.
+- **`options`**: Download options.
+- **`options.project`**: The Google Cloud project ID. Defaults to
+  `BUCKET_PROJECT`.
+- **`options.bucket`**: The Google Cloud Storage bucket name. Defaults to
+  `BUCKET_NAME`.
+
+##### Returns
+
+The table, so methods can be chained.
+
+##### Examples
+
+```ts
+// Set BUCKET_PROJECT and BUCKET_NAME in .env, and configure Google Application Default Credentials.
+await sdb
+  .newTable("results")
+  .loadBucket("exports/results.parquet")
+  .filter("value > 0")
+  .log();
+```
+
+```ts
+await sdb
+  .newTable("districts")
+  .loadBucket("maps/districts.shp.zip", {
+    project: "my-project",
+    bucket: "my-bucket",
+  })
+  .log();
+```
+
 #### `toSheet`
 
 Writes the table data to a Google Sheet. This method uses the `pushToSheet`

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # The Simple Data Analysis Library
 
-> Fast DuckDB-powered TypeScript library for tabular, geospatial, vector, AI, Google Sheets, and data visualization workflows on Deno, Node.js, and Bun.
+> Fast DuckDB-powered TypeScript library for tabular, geospatial, vector, AI, Google Cloud Storage, Google Sheets, and data visualization workflows on Deno, Node.js, and Bun.
 
 - Package: `@nshiab/simple-data-analysis`
 - Version: `6.0.1`

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -9,6 +9,8 @@ import aiVectorSimilarity from "../methods/aiVectorSimilarity.ts";
 import hybridSearch from "../methods/hybridSearch.ts";
 import aiRAG from "../methods/aiRAG.ts";
 import aiQuery from "../methods/aiQuery.ts";
+import toBucket from "../methods/toBucket.ts";
+import loadBucket from "../methods/loadBucket.ts";
 import loadSheet from "../methods/loadSheet.ts";
 import loadDatawrapper from "../methods/loadDatawrapper.ts";
 import loadGeoDatawrapper from "../methods/loadGeoDatawrapper.ts";
@@ -1264,6 +1266,116 @@ export default class SimpleTable extends SimpleTableCore {
     } = {},
   ): this {
     return aiQuery(this, prompt, options) as this;
+  }
+
+  // ===================== GOOGLE CLOUD STORAGE METHODS =====================
+
+  /**
+   * Writes the table to a file and uploads it to a Google Cloud Storage bucket.
+   * Supported destinations are `.csv`, `.csv.gz`, `.json`, `.json.gz`,
+   * `.parquet`, `.geojson`, `.geoparquet`, and `.shp.zip`.
+   *
+   * This method uses the `toBucket` function from the
+   * [journalism-google library](https://jsr.io/@nshiab/journalism-google).
+   * Set `BUCKET_PROJECT` and `BUCKET_NAME` in your `.env` file, or pass
+   * `project` and `bucket`.
+   * Authentication uses Google Application Default Credentials. To load
+   * credentials from a specific JSON file, set `GOOGLE_APPLICATION_CREDENTIALS`
+   * in your `.env` file to that file's path.
+   *
+   * @param destination - The path and filename for the object within the bucket.
+   * @param options - Upload options.
+   * @param options.project - The Google Cloud project ID. Defaults to `BUCKET_PROJECT`.
+   * @param options.bucket - The Google Cloud Storage bucket name. Defaults to `BUCKET_NAME`.
+   * @param options.overwrite - If `true`, replaces an existing object. Cannot be combined with `skip`. Defaults to `false`.
+   * @param options.skip - If `true`, skips the upload when the object already exists. Cannot be combined with `overwrite`. Defaults to `false`.
+   * @param options.metadata - Metadata passed to `journalism-google` for the uploaded object.
+   * @returns The `gs://` URI of the uploaded object.
+   * @category Exporting Data
+   *
+   * @example
+   * ```ts
+   * // Set BUCKET_PROJECT and BUCKET_NAME in .env, and configure Google Application Default Credentials.
+   * const uri = await sdb
+   *   .newTable("results")
+   *   .loadData("results.csv")
+   *   .selectColumns(["name", "value"])
+   *   .toBucket("exports/results.parquet", { overwrite: true });
+   * console.log(uri); // gs://my-bucket/exports/results.parquet
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Export a geometry table as one zipped Shapefile object.
+   * await sdb
+   *   .newTable("districts")
+   *   .loadGeoData("districts.geojson")
+   *   .toBucket("maps/districts.shp.zip", {
+   *     project: "my-project",
+   *     bucket: "my-bucket",
+   *   });
+   * ```
+   */
+  async toBucket(destination: string, options: {
+    project?: string;
+    bucket?: string;
+    overwrite?: boolean;
+    skip?: boolean;
+    metadata?: unknown;
+  } = {}): Promise<string> {
+    return await toBucket(this, destination, options);
+  }
+
+  /**
+   * Downloads a file from Google Cloud Storage and loads it into the table.
+   * Supported sources are `.csv`, `.csv.gz`, `.json`, `.json.gz`, `.parquet`,
+   * `.geojson`, `.geoparquet`, and `.shp.zip`.
+   *
+   * This method uses the `downloadFromBucket` function from the
+   * [journalism-google library](https://jsr.io/@nshiab/journalism-google).
+   * Set `BUCKET_PROJECT` and `BUCKET_NAME` in your `.env` file, or pass
+   * `project` and `bucket`.
+   * Authentication uses Google Application Default Credentials. To load
+   * credentials from a specific JSON file, set `GOOGLE_APPLICATION_CREDENTIALS`
+   * in your `.env` file to that file's path.
+   *
+   * The download and load are queued and run in chain order at the next awaited
+   * observer or `run()` call.
+   *
+   * @param source - The path and filename of the object within the bucket.
+   * @param options - Download options.
+   * @param options.project - The Google Cloud project ID. Defaults to `BUCKET_PROJECT`.
+   * @param options.bucket - The Google Cloud Storage bucket name. Defaults to `BUCKET_NAME`.
+   * @returns The table, so methods can be chained.
+   * @category Loading Data
+   *
+   * @example
+   * ```ts
+   * // Set BUCKET_PROJECT and BUCKET_NAME in .env, and configure Google Application Default Credentials.
+   * await sdb
+   *   .newTable("results")
+   *   .loadBucket("exports/results.parquet")
+   *   .filter("value > 0")
+   *   .log();
+   * ```
+   *
+   * @example
+   * ```ts
+   * await sdb
+   *   .newTable("districts")
+   *   .loadBucket("maps/districts.shp.zip", {
+   *     project: "my-project",
+   *     bucket: "my-bucket",
+   *   })
+   *   .log();
+   * ```
+   */
+  loadBucket(source: string, options: {
+    project?: string;
+    bucket?: string;
+  } = {}): this {
+    loadBucket(this, source, options);
+    return this;
   }
 
   // ===================== GOOGLE SHEETS METHODS =====================

--- a/src/helpers/classifyBucketFile.ts
+++ b/src/helpers/classifyBucketFile.ts
@@ -1,0 +1,52 @@
+export type BucketFileKind = "data" | "geo";
+
+export type BucketFile = {
+  kind: BucketFileKind;
+  compressed: boolean;
+};
+
+const supportedExtensions = [
+  ".csv",
+  ".csv.gz",
+  ".json",
+  ".json.gz",
+  ".parquet",
+  ".geojson",
+  ".geoparquet",
+  ".shp.zip",
+];
+
+/**
+ * Classifies a Google Cloud Storage object path using its strict file suffix.
+ *
+ * @param path - The object path to classify.
+ * @returns The file kind and whether it uses GZIP compression.
+ * @internal
+ */
+export default function classifyBucketFile(path: string): BucketFile {
+  const lowerPath = path.toLowerCase();
+
+  if (lowerPath.endsWith(".shp.zip")) {
+    return { kind: "geo", compressed: false };
+  }
+  if (
+    lowerPath.endsWith(".geojson") || lowerPath.endsWith(".geoparquet")
+  ) {
+    return { kind: "geo", compressed: false };
+  }
+  if (lowerPath.endsWith(".csv.gz") || lowerPath.endsWith(".json.gz")) {
+    return { kind: "data", compressed: true };
+  }
+  if (
+    lowerPath.endsWith(".csv") || lowerPath.endsWith(".json") ||
+    lowerPath.endsWith(".parquet")
+  ) {
+    return { kind: "data", compressed: false };
+  }
+
+  throw new Error(
+    `Bucket methods do not support the file extension in ${
+      JSON.stringify(path)
+    }. Use ${supportedExtensions.join(", ")}.`,
+  );
+}

--- a/src/helpers/withTemporaryDirectory.ts
+++ b/src/helpers/withTemporaryDirectory.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Runs work in a unique temporary directory and removes it afterwards.
+ *
+ * @param prefix - The temporary directory name prefix.
+ * @param operation - The work to run with the temporary directory path.
+ * @returns The result of the operation.
+ * @internal
+ */
+export default async function withTemporaryDirectory<T>(
+  prefix: string,
+  operation: (directory: string) => Promise<T>,
+): Promise<T> {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  let outcome:
+    | { success: true; value: T }
+    | { success: false; error: unknown };
+
+  try {
+    outcome = { success: true, value: await operation(directory) };
+  } catch (error) {
+    outcome = { success: false, error };
+  }
+
+  try {
+    await rm(directory, { recursive: true, force: true });
+  } catch (cleanupError) {
+    if (!outcome.success) {
+      throw new AggregateError(
+        [outcome.error, cleanupError],
+        "The bucket operation and temporary-file cleanup both failed.",
+        { cause: outcome.error },
+      );
+    }
+    throw cleanupError;
+  }
+
+  if (!outcome.success) {
+    throw outcome.error;
+  }
+  return outcome.value;
+}

--- a/src/methods/loadBucket.ts
+++ b/src/methods/loadBucket.ts
@@ -1,0 +1,47 @@
+import { basename, join } from "node:path";
+import { queueAsyncBarrier } from "@nshiab/simple-data-analysis-core/helpers";
+import classifyBucketFile from "../helpers/classifyBucketFile.ts";
+import withTemporaryDirectory from "../helpers/withTemporaryDirectory.ts";
+import type SimpleTable from "../class/SimpleTable.ts";
+
+type LoadBucketOptions = {
+  project?: string;
+  bucket?: string;
+};
+
+export default function loadBucket(
+  table: SimpleTable,
+  source: string,
+  options: LoadBucketOptions = {},
+): SimpleTable {
+  const file = classifyBucketFile(source);
+  options = structuredClone(options);
+
+  queueAsyncBarrier(table, {
+    method: "loadBucket()",
+    parameters: { source, options },
+    execute: async () => {
+      await withTemporaryDirectory(
+        "sda-bucket-download-",
+        async (directory) => {
+          const localFile = join(directory, basename(source));
+          const { downloadFromBucket } = await import(
+            "@nshiab/journalism-google"
+          );
+          await downloadFromBucket(source, localFile, {
+            project: options.project,
+            bucket: options.bucket,
+          });
+
+          if (file.kind === "data") {
+            table.loadData(localFile);
+          } else {
+            table.loadGeoData(localFile);
+          }
+          await table.run();
+        },
+      );
+    },
+  });
+  return table;
+}

--- a/src/methods/toBucket.ts
+++ b/src/methods/toBucket.ts
@@ -1,0 +1,60 @@
+import { basename, join } from "node:path";
+import classifyBucketFile from "../helpers/classifyBucketFile.ts";
+import withTemporaryDirectory from "../helpers/withTemporaryDirectory.ts";
+import type SimpleTable from "../class/SimpleTable.ts";
+
+type ToBucketOptions = {
+  project?: string;
+  bucket?: string;
+  overwrite?: boolean;
+  skip?: boolean;
+  metadata?: unknown;
+};
+
+export default async function toBucket(
+  table: SimpleTable,
+  destination: string,
+  options: ToBucketOptions = {},
+): Promise<string> {
+  options = structuredClone(options);
+  const file = classifyBucketFile(destination);
+  assertOptions(options);
+
+  return await withTemporaryDirectory(
+    "sda-bucket-upload-",
+    async (directory) => {
+      let localFile = join(directory, basename(destination));
+
+      if (file.kind === "data") {
+        if (file.compressed) {
+          localFile = localFile.slice(0, -".gz".length);
+          await table.writeData(localFile, { compression: true });
+          localFile += ".gz";
+        } else {
+          await table.writeData(localFile);
+        }
+      } else {
+        await table.writeGeoData(localFile);
+      }
+
+      const { toBucket: uploadToBucket } = await import(
+        "@nshiab/journalism-google"
+      );
+      return await uploadToBucket(localFile, destination, {
+        project: options.project,
+        bucket: options.bucket,
+        overwrite: options.overwrite,
+        skip: options.skip,
+        metadata: options.metadata,
+      });
+    },
+  );
+}
+
+function assertOptions(options: ToBucketOptions): void {
+  if (options.skip === true && options.overwrite === true) {
+    throw new Error(
+      "Cannot use both skip and overwrite. Choose one existing-object behavior.",
+    );
+  }
+}

--- a/test/fixtures/lazyImports/google.ts
+++ b/test/fixtures/lazyImports/google.ts
@@ -1,4 +1,5 @@
-import { calls, loaded } from "./state.ts";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { bucketObjects, calls, loaded } from "./state.ts";
 loaded.push("google");
 
 export function getSheetData(_url: string, options: {
@@ -12,5 +13,38 @@ export function getSheetData(_url: string, options: {
 
 export function pushToSheet(data: unknown) {
   calls.push({ method: "pushToSheet", value: data });
+  return Promise.resolve();
+}
+
+export function toBucket(
+  file: string,
+  destination: string,
+  options: unknown,
+) {
+  bucketObjects.set(destination, readFileSync(file));
+  calls.push({
+    method: "toBucket",
+    value: { destination, options, fileExists: existsSync(file) },
+    path: file,
+  });
+  const bucket = (options as { bucket?: string }).bucket ?? "fixture-bucket";
+  return Promise.resolve(`gs://${bucket}/${destination}`);
+}
+
+export function downloadFromBucket(
+  source: string,
+  destination: string,
+  options: unknown,
+) {
+  const data = bucketObjects.get(source);
+  if (data === undefined) {
+    throw new Error(`Missing fixture bucket object ${source}`);
+  }
+  writeFileSync(destination, data);
+  calls.push({
+    method: "downloadFromBucket",
+    value: { source, options, fileExists: existsSync(destination) },
+    path: destination,
+  });
   return Promise.resolve();
 }

--- a/test/fixtures/lazyImports/googleFailure.ts
+++ b/test/fixtures/lazyImports/googleFailure.ts
@@ -1,3 +1,5 @@
 throw new Error("Google module could not load");
 export function getSheetData() {}
 export function pushToSheet() {}
+export function toBucket() {}
+export function downloadFromBucket() {}

--- a/test/fixtures/lazyImports/scenario.ts
+++ b/test/fixtures/lazyImports/scenario.ts
@@ -1,5 +1,6 @@
 import { assertArrayIncludes, assertEquals, assertRejects } from "@std/assert";
-import { calls, loaded } from "./state.ts";
+import { existsSync } from "node:fs";
+import { bucketObjects, calls, loaded } from "./state.ts";
 import { SimpleDB } from "../../../src/index.ts";
 
 assertEquals(loaded, [], "Importing SDA must not evaluate integrations");
@@ -138,6 +139,102 @@ try {
         chartId: "map-id",
         options: { apiKey: "CUSTOM_DATAWRAPPER_KEY" },
       });
+      break;
+    }
+    case "bucket": {
+      const source = sdb.newTable("bucketSource").loadArray([
+        { value: 1, label: "one" },
+        { value: 2, label: "two" },
+      ]);
+      assertEquals(loaded, []);
+
+      for (
+        const destination of [
+          "data/results.csv",
+          "data/results.csv.gz",
+          "data/results.json",
+          "data/results.json.gz",
+          "data/results.parquet",
+        ]
+      ) {
+        const uri = await source.toBucket(destination, {
+          project: "fixture-project",
+          bucket: "fixture-bucket",
+          overwrite: true,
+          metadata: { contentType: "application/octet-stream" },
+        });
+        assertEquals(uri, `gs://fixture-bucket/${destination}`);
+        const upload = calls.at(-1)!;
+        assertEquals(upload.method, "toBucket");
+        assertEquals(
+          (upload.value as { fileExists: boolean }).fileExists,
+          true,
+        );
+        assertEquals(
+          (upload.value as { options: { metadata: unknown } }).options.metadata,
+          { contentType: "application/octet-stream" },
+        );
+        assertEquals(existsSync(upload.path!), false);
+
+        const loadedTable = sdb.newTable().loadBucket(destination, {
+          project: "fixture-project",
+          bucket: "fixture-bucket",
+        });
+        assertEquals(await loadedTable.filter("value > 1").getData(), [
+          { value: 2, label: "two" },
+        ]);
+        const download = calls.at(-1)!;
+        assertEquals(download.method, "downloadFromBucket");
+        assertEquals(
+          (download.value as { fileExists: boolean }).fileExists,
+          true,
+        );
+        assertEquals(existsSync(download.path!), false);
+      }
+
+      const geoSource = sdb.newTable("geoSource").loadGeoData(
+        "test/geodata/files/CanadianProvincesAndTerritories.json",
+      );
+      for (
+        const destination of [
+          "geo/provinces.geojson",
+          "geo/provinces.geoparquet",
+          "geo/provinces.shp.zip",
+        ]
+      ) {
+        await geoSource.toBucket(destination, {
+          project: "fixture-project",
+          bucket: "fixture-bucket",
+        });
+        const loadedGeoTable = sdb.newTable().loadBucket(destination, {
+          project: "fixture-project",
+          bucket: "fixture-bucket",
+        });
+        assertEquals(await loadedGeoTable.getRowCount(), 13);
+      }
+      assertEquals(loaded, ["google"]);
+      break;
+    }
+    case "bucket-queued": {
+      bucketObjects.set(
+        "data/queued.csv",
+        new TextEncoder().encode("value\n1\n2\n"),
+      );
+      const options = {
+        project: "fixture-project",
+        bucket: "fixture-bucket",
+      };
+      assertEquals(table.loadBucket("data/queued.csv", options), table);
+      options.project = "changed-after-queueing";
+      table.filter("value > 1");
+      assertEquals(loaded, [], "Queueing must not load the Google module");
+      assertEquals(await table.getData(), [{ value: 2 }]);
+      assertEquals(loaded, ["google"]);
+      assertEquals(calls.at(-1)?.method, "downloadFromBucket");
+      assertEquals(
+        (calls.at(-1)?.value as { options: unknown }).options,
+        { project: "fixture-project", bucket: "fixture-bucket" },
+      );
       break;
     }
     case "observers":

--- a/test/fixtures/lazyImports/state.ts
+++ b/test/fixtures/lazyImports/state.ts
@@ -1,2 +1,3 @@
 export const loaded: string[] = [];
 export const calls: { method: string; value: unknown; path?: string }[] = [];
+export const bucketObjects = new Map<string, Uint8Array>();

--- a/test/runtime/lazyImports.cjs
+++ b/test/runtime/lazyImports.cjs
@@ -52,6 +52,15 @@ async function main() {
       /Google service account email is undefined or empty/,
     );
 
+    await assert.rejects(
+      table.toBucket("unsupported.txt"),
+      /Bucket methods do not support the file extension/,
+    );
+    assert.throws(
+      () => table.loadBucket("unsupported.txt"),
+      /Bucket methods do not support the file extension/,
+    );
+
     let requests = 0;
     globalThis.fetch = () => {
       requests++;

--- a/test/unit/class/lazyImports.test.ts
+++ b/test/unit/class/lazyImports.test.ts
@@ -11,6 +11,8 @@ for (
     "queued",
     "ai",
     "datawrapper",
+    "bucket",
+    "bucket-queued",
     "observers",
     "observers-reversed",
     "failure",

--- a/test/unit/helpers/classifyBucketFile.test.ts
+++ b/test/unit/helpers/classifyBucketFile.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import classifyBucketFile from "../../../src/helpers/classifyBucketFile.ts";
+
+Deno.test("classifyBucketFile recognizes strict tabular suffixes", () => {
+  for (
+    const path of [
+      "data.csv",
+      "folder/data.json",
+      "data.parquet",
+    ]
+  ) {
+    assertEquals(classifyBucketFile(path), {
+      kind: "data",
+      compressed: false,
+    });
+  }
+  for (const path of ["data.csv.gz", "folder/data.JSON.GZ"]) {
+    assertEquals(classifyBucketFile(path), {
+      kind: "data",
+      compressed: true,
+    });
+  }
+});
+
+Deno.test("classifyBucketFile recognizes strict geospatial suffixes", () => {
+  for (
+    const path of [
+      "map.geojson",
+      "folder/map.GEOPARQUET",
+      "map.shp.zip",
+    ]
+  ) {
+    assertEquals(classifyBucketFile(path), {
+      kind: "geo",
+      compressed: false,
+    });
+  }
+});
+
+Deno.test("classifyBucketFile rejects unsupported suffixes", () => {
+  for (
+    const path of [
+      "map.shp",
+      "map.geojson.gz",
+      "data.xlsx",
+      "data.sqlite",
+      "no-extension",
+    ]
+  ) {
+    assertThrows(
+      () => classifyBucketFile(path),
+      Error,
+      "Bucket methods do not support the file extension",
+    );
+  }
+});

--- a/test/unit/helpers/withTemporaryDirectory.test.ts
+++ b/test/unit/helpers/withTemporaryDirectory.test.ts
@@ -1,0 +1,32 @@
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { existsSync } from "node:fs";
+import withTemporaryDirectory from "../../../src/helpers/withTemporaryDirectory.ts";
+
+Deno.test("withTemporaryDirectory starts work synchronously and cleans up", async () => {
+  let directory = "";
+  let started = false;
+  const result = withTemporaryDirectory("sda-test-", (path) => {
+    directory = path;
+    started = true;
+    assert(existsSync(path));
+    return Promise.resolve("done");
+  });
+
+  assert(started);
+  assertEquals(await result, "done");
+  assertEquals(existsSync(directory), false);
+});
+
+Deno.test("withTemporaryDirectory cleans up after an operation fails", async () => {
+  let directory = "";
+  await assertRejects(
+    () =>
+      withTemporaryDirectory("sda-test-", (path) => {
+        directory = path;
+        return Promise.reject(new Error("operation failed"));
+      }),
+    Error,
+    "operation failed",
+  );
+  assertEquals(existsSync(directory), false);
+});

--- a/test/unit/methods/loadBucket.test.ts
+++ b/test/unit/methods/loadBucket.test.ts
@@ -1,0 +1,117 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { SimpleDB } from "../../../src/index.ts";
+
+const bucketProject = Deno.env.get("BUCKET_PROJECT");
+const bucketName = Deno.env.get("BUCKET_NAME");
+const runLiveBucketTests = typeof bucketProject === "string" &&
+  bucketProject !== "" &&
+  typeof bucketName === "string" && bucketName !== "";
+
+Deno.test("loadBucket rejects unsupported sources at call time", async () => {
+  const sdb = new SimpleDB();
+  try {
+    const table = sdb.newTable();
+    assertThrows(
+      () => table.loadBucket("data.xlsx"),
+      Error,
+      "Bucket methods do not support the file extension",
+    );
+  } finally {
+    await sdb.close();
+  }
+});
+
+if (runLiveBucketTests) {
+  Deno.test("loadBucket loads live tabular data", {
+    sanitizeResources: false,
+  }, async () => {
+    const destination =
+      `simple-data-analysis-tests/${crypto.randomUUID()}.json`;
+    const expected = [
+      { city: "Montreal", temperature: 31 },
+      { city: "Toronto", temperature: 33 },
+    ];
+
+    await withLiveBucketObject(
+      destination,
+      JSON.stringify(expected),
+      async () => {
+        const sdb = new SimpleDB();
+        try {
+          assertEquals(
+            await sdb
+              .newTable("liveBucketData")
+              .loadBucket(destination)
+              .sort({ city: "asc" })
+              .getData(),
+            expected,
+          );
+        } finally {
+          await sdb.close();
+        }
+      },
+    );
+  });
+
+  Deno.test("loadBucket loads live geospatial data", {
+    sanitizeResources: false,
+  }, async () => {
+    const destination =
+      `simple-data-analysis-tests/${crypto.randomUUID()}.geojson`;
+    const expected = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [-73.5674, 45.5019] },
+        properties: { city: "Montreal" },
+      }],
+    };
+
+    await withLiveBucketObject(
+      destination,
+      JSON.stringify(expected),
+      async () => {
+        const sdb = new SimpleDB();
+        try {
+          assertEquals(
+            await sdb
+              .newTable("liveBucketGeoData")
+              .loadBucket(destination)
+              .getGeoData(),
+            expected,
+          );
+        } finally {
+          await sdb.close();
+        }
+      },
+    );
+  });
+} else {
+  console.log(
+    "No BUCKET_PROJECT or BUCKET_NAME in process.env, skipping live loadBucket tests",
+  );
+}
+
+async function withLiveBucketObject(
+  destination: string,
+  contents: string,
+  operation: () => Promise<void>,
+): Promise<void> {
+  const { deleteFromBucket, toBucket } = await import(
+    "@nshiab/journalism-google"
+  );
+  const localFile = await Deno.makeTempFile();
+  let uploaded = false;
+
+  try {
+    await Deno.writeTextFile(localFile, contents);
+    await toBucket(localFile, destination);
+    uploaded = true;
+    await operation();
+  } finally {
+    await Deno.remove(localFile);
+    if (uploaded) {
+      await deleteFromBucket(destination, { try: true });
+    }
+  }
+}

--- a/test/unit/methods/toBucket.test.ts
+++ b/test/unit/methods/toBucket.test.ts
@@ -1,0 +1,134 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { SimpleDB } from "../../../src/index.ts";
+
+const bucketProject = Deno.env.get("BUCKET_PROJECT");
+const bucketName = Deno.env.get("BUCKET_NAME");
+const runLiveBucketTests = typeof bucketProject === "string" &&
+  bucketProject !== "" &&
+  typeof bucketName === "string" && bucketName !== "";
+
+Deno.test("toBucket rejects unsupported destinations", async () => {
+  const sdb = new SimpleDB();
+  try {
+    const table = sdb.newTable().loadArray([{ value: 1 }]);
+    await assertRejects(
+      () => table.toBucket("data.xlsx"),
+      Error,
+      "Bucket methods do not support the file extension",
+    );
+  } finally {
+    await sdb.close();
+  }
+});
+
+Deno.test("toBucket rejects conflicting existing-object behavior", async () => {
+  const sdb = new SimpleDB();
+  try {
+    const table = sdb.newTable().loadArray([{ value: 1 }]);
+    await assertRejects(
+      () =>
+        table.toBucket("data.csv", {
+          overwrite: true,
+          skip: true,
+        }),
+      Error,
+      "Cannot use both skip and overwrite",
+    );
+  } finally {
+    await sdb.close();
+  }
+});
+
+Deno.test("toBucket relies on core geometry validation", async () => {
+  const sdb = new SimpleDB();
+  try {
+    const table = sdb.newTable().loadArray([{ value: 1 }]);
+    await assertRejects(
+      () => table.toBucket("data.geojson"),
+      Error,
+      "Table contains no geometry columns. Use writeData() instead.",
+    );
+  } finally {
+    await sdb.close();
+  }
+});
+
+if (runLiveBucketTests) {
+  Deno.test("bucket methods round-trip live tabular data", {
+    sanitizeResources: false,
+  }, async () => {
+    const destination =
+      `simple-data-analysis-tests/${crypto.randomUUID()}.parquet`;
+    const expected = [
+      { city: "Montreal", temperature: 31 },
+      { city: "Toronto", temperature: 33 },
+    ];
+    const sdb = new SimpleDB();
+    let uploaded = false;
+
+    try {
+      const uri = await sdb
+        .newTable("bucketUpload")
+        .loadArray(expected)
+        .toBucket(destination);
+      uploaded = true;
+      assertEquals(uri, `gs://${bucketName}/${destination}`);
+
+      assertEquals(
+        await sdb
+          .newTable("bucketDownload")
+          .loadBucket(destination)
+          .sort({ city: "asc" })
+          .getData(),
+        expected,
+      );
+    } finally {
+      await sdb.close();
+      if (uploaded) {
+        const { deleteFromBucket } = await import(
+          "@nshiab/journalism-google"
+        );
+        await deleteFromBucket(destination, { try: true });
+      }
+    }
+  });
+
+  Deno.test("bucket methods round-trip live geospatial data", {
+    sanitizeResources: false,
+  }, async () => {
+    const destination =
+      `simple-data-analysis-tests/${crypto.randomUUID()}.geoparquet`;
+    const sdb = new SimpleDB();
+    let uploaded = false;
+
+    try {
+      const uri = await sdb
+        .newTable("bucketGeoUpload")
+        .loadGeoData(
+          "test/geodata/files/CanadianProvincesAndTerritories.json",
+        )
+        .toBucket(destination);
+      uploaded = true;
+      assertEquals(uri, `gs://${bucketName}/${destination}`);
+
+      const geoData = await sdb
+        .newTable("bucketGeoDownload")
+        .loadBucket(destination)
+        .getGeoData();
+      assertEquals(geoData.type, "FeatureCollection");
+      assertEquals(geoData.features.length, 13);
+    } finally {
+      await sdb.close();
+      if (uploaded) {
+        const { deleteFromBucket } = await import(
+          "@nshiab/journalism-google"
+        );
+        await deleteFromBucket(destination, { try: true });
+      }
+    }
+  });
+} else {
+  console.log(
+    "No BUCKET_PROJECT or BUCKET_NAME in process.env, skipping live bucket tests",
+  );
+}


### PR DESCRIPTION
## Summary
- add `toBucket()` and `loadBucket()` to `SimpleTable`
- support strict tabular and geospatial file extensions with automatic routing
- add lazy-integration, cleanup, unit, and opt-in live Google Cloud Storage tests
- document bucket configuration and load/transform/upload examples

## Validation
- `deno task all-tests`
- live tabular and geospatial bucket round trips for both public methods