### PR TITLE
Preserve SQL data during AI column enrichment

### DIFF
--- a/llm.md
+++ b/llm.md
@@ -699,6 +699,12 @@ By default, a failed batch throws. Set `errorColumn` to store the error on every
 row in the failed batch, set its output columns to `NULL`, and continue
 processing other batches. Successful rows contain `NULL` in the error column.
 
+Only the input column and generated columns pass through JavaScript. Unrelated
+SQL values and types, including vectors and geometry, remain in DuckDB.
+Generated columns are staged in bounded batches and replace existing output
+columns with inferred types. Uncaught generation or staging failures leave the
+original table data unchanged.
+
 This method queues the AI processing; requests are sent when an async observer
 method (like `getData()` or `log()`) is awaited, or when `run()` is called.
 
@@ -867,6 +873,11 @@ using the [duckdb-vss extension](https://github.com/duckdb/duckdb-vss). This is
 useful for speeding up the `aiVectorSimilarity` method. When refreshing an
 existing embedding column, its managed VSS index is dropped and rebuilt if
 `createIndex` is `true`.
+
+Only the input text and generated vectors pass through JavaScript. Unrelated SQL
+values and types remain in DuckDB. Vectors are staged in bounded batches before
+replacing the output column, including when dimensions change. Uncaught
+generation or staging failures leave the original table data unchanged.
 
 The work is queued and runs in chain order at the next awaited observer or
 `run()` call.
@@ -1065,7 +1076,8 @@ This method:
 1. Ensures compatible embeddings exist for the text column
 2. Runs vector similarity search and BM25 text search in parallel
 3. Fuses the results using Reciprocal Rank Fusion to get the best matches
-4. Returns a new table with the top results ordered by relevance
+4. Returns the top results ordered by relevance, replacing the current table
+   unless `outputTable` is specified
 
 When vector search is enabled, embedding responses are cached in
 `.journalism-cache`, and the table with its generated embedding column is cached

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -88,6 +88,8 @@ export default class SimpleTable extends SimpleTableCore {
    *
    * By default, a failed batch throws. Set `errorColumn` to store the error on every row in the failed batch, set its output columns to `NULL`, and continue processing other batches. Successful rows contain `NULL` in the error column.
    *
+   * Only the input column and generated columns pass through JavaScript. Unrelated SQL values and types, including vectors and geometry, remain in DuckDB. Generated columns are staged in bounded batches and replace existing output columns with inferred types. Uncaught generation or staging failures leave the original table data unchanged.
+   *
    * This method queues the AI processing; requests are sent when an async observer method (like `getData()` or `log()`) is awaited, or when `run()` is called.
    *
    * @param column - The name of the column to be used as input for the AI prompt.
@@ -319,6 +321,8 @@ export default class SimpleTable extends SimpleTableCore {
    * Every call generates embeddings from the current text and replaces the output column if it already exists. Unchanged text can reuse cached embedding responses. Call this method again after changing the source text to refresh its embeddings.
    *
    * If `createIndex` is `true`, an HNSW index will be created on the new column using the [duckdb-vss extension](https://github.com/duckdb/duckdb-vss). This is useful for speeding up the `aiVectorSimilarity` method. When refreshing an existing embedding column, its managed VSS index is dropped and rebuilt if `createIndex` is `true`.
+   *
+   * Only the input text and generated vectors pass through JavaScript. Unrelated SQL values and types remain in DuckDB. Vectors are staged in bounded batches before replacing the output column, including when dimensions change. Uncaught generation or staging failures leave the original table data unchanged.
    *
    * The work is queued and runs in chain order at the next awaited observer or `run()` call.
    *

--- a/src/helpers/runAIRequestPool.ts
+++ b/src/helpers/runAIRequestPool.ts
@@ -5,6 +5,8 @@ type PoolOptions = {
   retryCheck?: (error: unknown) => Promise<boolean> | boolean;
   minRequestIntervalMs?: number;
   logProgress?: boolean;
+  /** Shares request pacing and progress across sequential transfer batches. */
+  state?: { nextRequestStart: number; completed: number; total: number };
 };
 
 /** Runs indexed AI request tasks with bounded concurrency and retry handling. */
@@ -23,14 +25,17 @@ export default async function runAIRequestPool<T>(
   const results: (T | undefined)[] = Array(tasks.length).fill(undefined);
   const errors: (unknown | undefined)[] = Array(tasks.length).fill(undefined);
   let nextIndex = 0;
-  let completed = 0;
-  let nextRequestStart = 0;
+  const state = options.state ?? {
+    nextRequestStart: 0,
+    completed: 0,
+    total: tasks.length,
+  };
 
   const beforeRequest = async () => {
     const interval = options.minRequestIntervalMs ?? 0;
     const now = Date.now();
-    const requestStart = Math.max(now, nextRequestStart);
-    nextRequestStart = requestStart + interval;
+    const requestStart = Math.max(now, state.nextRequestStart);
+    state.nextRequestStart = requestStart + interval;
     const wait = requestStart - now;
     if (wait > 0) {
       await sleep(wait);
@@ -57,9 +62,9 @@ export default async function runAIRequestPool<T>(
         }
       }
 
-      completed++;
+      state.completed++;
       if (options.logProgress) {
-        console.log(`Processed ${completed} of ${tasks.length} requests.`);
+        console.log(`Processed ${state.completed} of ${state.total} requests.`);
       }
     }
   };

--- a/src/methods/aiEmbeddings.ts
+++ b/src/methods/aiEmbeddings.ts
@@ -4,7 +4,10 @@ import {
   snapshotAIOptions,
 } from "../helpers/aiOptions.ts";
 import ensureEmbeddingColumn from "../helpers/ensureEmbeddingColumn.ts";
-import { queueAsyncBarrier } from "@nshiab/simple-data-analysis-core/helpers";
+import {
+  queueAsyncBarrier,
+  updateColumnsWithJS,
+} from "@nshiab/simple-data-analysis-core/helpers";
 
 /**
  * Options for generating an embedding column.
@@ -107,78 +110,81 @@ export async function generateEmbeddingColumn(
   newColumn: string,
   options: AIEmbeddingsOptions = {},
 ): Promise<void> {
-  const replacing = await simpleTable.hasColumn(newColumn);
-  // Core preserves existing SQL types during JS updates. Generate into a new
-  // column so a refreshed model can return a different vector dimension.
-  const targetColumn = replacing
-    ? `__sda_embeddings_${crypto.randomUUID().replaceAll("-", "")}`
-    : newColumn;
-  await simpleTable.updateWithJS(async (rows) => {
-    const [{ formatNumber }, { default: sleep }, { default: tryEmbedding }] =
-      await Promise.all([
-        import("@nshiab/journalism-format"),
-        import("../helpers/sleep.ts"),
-        import("../helpers/tryEmbedding.ts"),
-      ]);
-    if (options.verbose) {
-      console.log("\naiEmbeddings()");
-    }
-
-    const concurrency = options.concurrency ?? 1;
-
-    let requests = [];
-    for (let i = 0; i < rows.length; i++) {
-      if (options.verbose) {
-        console.log(
-          `Processing row ${i + 1} of ${rows.length}... (${
-            formatNumber(
-              (i + 1) / rows.length * 100,
-              {
-                significantDigits: 3,
-                suffix: "%",
-              },
-            )
-          })`,
-        );
-      }
-
-      if (requests.length < concurrency) {
-        const text = rows[i][column];
-        if (typeof text !== "string") {
-          throw new Error(
-            `The column "${column}" must be a string. Found ${text} instead.`,
-          );
-        }
-        requests.push(
-          tryEmbedding(i, rows, text, targetColumn, options),
-        );
-      }
-
-      if (requests.length === concurrency || i + 1 >= rows.length) {
-        const start = new Date();
-        await Promise.all(requests);
-        const end = new Date();
-
-        const duration = end.getTime() - start.getTime();
-        // If duration is less than 10ms per request, it should means data comes from cache and we don't need to wait
-        if (
-          typeof options.rateLimitPerMinute === "number" &&
-          duration > 10 * requests.length && i + 1 < rows.length
-        ) {
-          const delay = Math.round(
-            (60 / (options.rateLimitPerMinute / concurrency)) * 1000,
-          );
-          await sleep(delay, { start, log: options.verbose });
-        }
-
-        requests = [];
-      }
-    }
-
-    return rows;
-  });
-  if (replacing && await simpleTable.hasColumn(targetColumn)) {
-    await simpleTable.removeColumns(newColumn)
-      .renameColumns({ [targetColumn]: newColumn }).run();
+  const concurrency = options.concurrency ?? 1;
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1) {
+    throw new Error("concurrency must be a positive safe integer.");
   }
+  const total = await simpleTable.getRowCount();
+  let processed = 0;
+  if (options.verbose) console.log("\naiEmbeddings()");
+  await updateColumnsWithJS(
+    simpleTable,
+    [column],
+    [newColumn],
+    async (rows) => {
+      const [{ formatNumber }, { default: sleep }, { default: tryEmbedding }] =
+        await Promise.all([
+          import("@nshiab/journalism-format"),
+          import("../helpers/sleep.ts"),
+          import("../helpers/tryEmbedding.ts"),
+        ]);
+      let requests = [];
+      for (let i = 0; i < rows.length; i++) {
+        if (options.verbose) {
+          console.log(
+            `Processing row ${processed + i + 1} of ${total}... (${
+              formatNumber(
+                (processed + i + 1) / total * 100,
+                {
+                  significantDigits: 3,
+                  suffix: "%",
+                },
+              )
+            })`,
+          );
+        }
+
+        if (requests.length < concurrency) {
+          const text = rows[i][column];
+          if (typeof text !== "string") {
+            throw new Error(
+              `The column "${column}" must be a string. Found ${text} instead.`,
+            );
+          }
+          requests.push(
+            tryEmbedding(i, rows, text, newColumn, options),
+          );
+        }
+
+        if (requests.length === concurrency || i + 1 >= rows.length) {
+          const start = new Date();
+          await Promise.all(requests);
+          const end = new Date();
+
+          const duration = end.getTime() - start.getTime();
+          // If duration is less than 10ms per request, it should means data comes from cache and we don't need to wait
+          if (
+            typeof options.rateLimitPerMinute === "number" &&
+            duration > 10 * requests.length && processed + i + 1 < total
+          ) {
+            const delay = Math.round(
+              (60 / (options.rateLimitPerMinute / concurrency)) * 1000,
+            );
+            await sleep(delay, { start, log: options.verbose });
+          }
+
+          requests = [];
+        }
+      }
+
+      processed += rows.length;
+      return rows;
+    },
+    {
+      batchSize: Math.max(
+        concurrency,
+        Math.floor(1000 / concurrency) * concurrency,
+      ),
+    },
+  );
 }

--- a/src/methods/aiRowByRow.ts
+++ b/src/methods/aiRowByRow.ts
@@ -1,3 +1,7 @@
+import {
+  queueAsyncBarrier,
+  updateColumnsWithJS,
+} from "@nshiab/simple-data-analysis-core/helpers";
 import type SimpleTable from "../class/SimpleTable.ts";
 import type {
   AIRequestMetrics,
@@ -60,24 +64,49 @@ export default function aiRowByRow(
   const newColumns = Array.isArray(newColumn) ? [...newColumn] : [newColumn];
   options = snapshotAIOptions(options);
 
-  table.updateWithJS(async (rows) => {
-    if (options.verbose) {
-      console.log("\naiRowByRow()");
-    }
+  queueAsyncBarrier(table, {
+    method: "aiRowByRow()",
+    parameters: { column, newColumn, prompt },
+    execute: () => runAIRowByRow(table, column, newColumns, prompt, options),
+  });
+}
 
-    const batchSize = options.batchSize ?? 1;
-    const concurrency = options.concurrency ?? 1;
-    if (!Number.isInteger(batchSize) || batchSize < 1) {
-      throw new Error("batchSize must be a positive integer.");
-    }
-    if (
-      options.rateLimitPerMinute !== undefined &&
-      (!Number.isFinite(options.rateLimitPerMinute) ||
-        options.rateLimitPerMinute <= 0)
-    ) {
-      throw new Error("rateLimitPerMinute must be greater than 0.");
-    }
+async function runAIRowByRow(
+  table: SimpleTable,
+  column: string,
+  newColumns: string[],
+  prompt: string,
+  options: AIRowByRowOptions,
+): Promise<void> {
+  if (options.verbose) {
+    console.log("\naiRowByRow()");
+  }
 
+  const batchSize = options.batchSize ?? 1;
+  const concurrency = options.concurrency ?? 1;
+  if (!Number.isSafeInteger(batchSize) || batchSize < 1) {
+    throw new Error("batchSize must be a positive integer.");
+  }
+  if (
+    options.rateLimitPerMinute !== undefined &&
+    (!Number.isFinite(options.rateLimitPerMinute) ||
+      options.rateLimitPerMinute <= 0)
+  ) {
+    throw new Error("rateLimitPerMinute must be greater than 0.");
+  }
+
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1) {
+    throw new Error("concurrency must be a positive safe integer.");
+  }
+  const state = {
+    nextRequestStart: 0,
+    completed: 0,
+    total: Math.ceil(await table.getRowCount() / batchSize),
+  };
+  const outputColumns = options.errorColumn === undefined
+    ? newColumns
+    : [...newColumns, options.errorColumn];
+  await updateColumnsWithJS(table, [column], outputColumns, async (rows) => {
     const [
       { default: askAI },
       { default: buildAIRowsRequest },
@@ -138,6 +167,7 @@ export default function aiRowByRow(
           ? undefined
           : 60_000 / options.rateLimitPerMinute,
         logProgress: options.logProgress,
+        state,
       },
     );
 
@@ -154,7 +184,6 @@ export default function aiRowByRow(
       if (result !== undefined) {
         for (let j = 0; j < result.length; j++) {
           newRows.push({
-            ...batches[i][j],
             ...result[j],
             ...(options.errorColumn === undefined
               ? {}
@@ -171,9 +200,8 @@ export default function aiRowByRow(
       const emptyResult = Object.fromEntries(
         newColumns.map((name) => [name, null]),
       );
-      for (const row of batches[i]) {
+      for (let j = 0; j < batches[i].length; j++) {
         newRows.push({
-          ...row,
           ...emptyResult,
           [options.errorColumn as string]: errorMessage,
         });
@@ -181,5 +209,7 @@ export default function aiRowByRow(
     }
 
     return newRows;
+  }, {
+    batchSize: Math.max(batchSize, Math.floor(1000 / batchSize) * batchSize),
   });
 }

--- a/test/unit/helpers/createAIEnrichmentFixture.ts
+++ b/test/unit/helpers/createAIEnrichmentFixture.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "@std/assert";
+import SimpleDB from "../../../src/class/SimpleDB.ts";
+
+/** Builds SQL-native values and compares them in DuckDB without JS conversion. */
+export default async function createAIEnrichmentFixture() {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("enriched");
+  await sdb.customQuery(`CREATE TABLE enriched AS SELECT
+    i, 'row-' || i AS text, 7 AS rowid,
+    9007199254740993::BIGINT AS exact,
+    DATE '2025-01-01' AS date,
+    1234567890123456.789::DECIMAL(19,3) AS amount,
+    TIMESTAMP_NS '2025-01-01 12:34:56.123456789' AS instant,
+    {'ids': [9007199254740993::BIGINT], 'values': [NULL, 1.234::DECIMAL(7,3)]} AS nested,
+    [1, 2]::FLOAT[2] AS existing_vector
+    FROM range(1003) t(i)`);
+  await sdb.customQuery("CREATE TABLE expected AS SELECT * FROM enriched");
+  const originalTypes = await table.getTypes();
+  return {
+    sdb,
+    table,
+    assertPreserved: async (outputs: string[] = []) => {
+      const types = await table.getTypes();
+      assertEquals(
+        Object.fromEntries(
+          Object.entries(types).filter(([name]) => !outputs.includes(name)),
+        ),
+        originalTypes,
+      );
+      const projection = Object.keys(originalTypes).map((name) => `"${name}"`)
+        .join(", ");
+      assertEquals(
+        await sdb.customQuery(
+          `SELECT count(*) AS differences FROM (
+        ((SELECT ${projection} FROM enriched) EXCEPT ALL (SELECT * FROM expected))
+        UNION ALL
+        ((SELECT * FROM expected) EXCEPT ALL (SELECT ${projection} FROM enriched))
+      )`,
+          { returnData: true },
+        ),
+        [{ differences: 0 }],
+      );
+      assertEquals(
+        (await sdb.getTableNames()).filter((name) =>
+          name.startsWith("__sda_") &&
+          name !== "__sda_embedding_column_metadata"
+        ),
+        [],
+      );
+    },
+  };
+}

--- a/test/unit/methods/aiEmbeddings.test.ts
+++ b/test/unit/methods/aiEmbeddings.test.ts
@@ -1,3 +1,4 @@
+import createAIEnrichmentFixture from "../helpers/createAIEnrichmentFixture.ts";
 import { assertEquals, assertRejects } from "@std/assert";
 import SimpleDB from "../../../src/class/SimpleDB.ts";
 import type SimpleTable from "../../../src/class/SimpleTable.ts";
@@ -826,4 +827,95 @@ if (Deno.env.get("AI_EMBEDDINGS_PROVIDER") === "ollama") {
   });
 } else {
   console.log("AI_EMBEDDINGS_PROVIDER is not set to ollama");
+}
+
+Deno.test("aiEmbeddings preserves SQL values and independent vectors across transfer batches", async () => {
+  const { sdb, table, assertPreserved } = await createAIEnrichmentFixture();
+  try {
+    for (
+      const [column, dimensions] of [
+        ["first", 2],
+        ["second", 3],
+        ["first", 4],
+        ["second", 2],
+      ] as const
+    ) {
+      let requests = 0;
+      const client = {
+        embeddingEndpoint: "http://lossless.local:11434",
+        embed: (request: { input: string | string[] }) => {
+          requests++;
+          const id = Number(String(request.input).slice(4));
+          return Promise.resolve({
+            embeddings: [[id, ...Array<number>(dimensions - 1).fill(1)]],
+          });
+        },
+      };
+      await table.aiEmbeddings("text", column, {
+        embeddings: {
+          provider: "ollama",
+          model: "lossless-test",
+          ollama: client,
+          cache: false,
+        },
+        concurrency: 3,
+      }).run();
+      assertEquals(requests, 1003);
+      const outputs = column === "first" && dimensions === 2
+        ? ["first"]
+        : ["first", "second"];
+      await assertPreserved(outputs);
+      assertEquals((await table.getTypes())[column], `FLOAT[${dimensions}]`);
+      for (const output of outputs) {
+        assertEquals(
+          await sdb.customQuery(
+            `SELECT count(*) AS valid FROM enriched
+          WHERE ${output}[1] = i AND array_cosine_similarity(${output}, ${output}) > 0.999`,
+            { returnData: true },
+          ),
+          [{ valid: 1003 }],
+        );
+      }
+    }
+  } finally {
+    await sdb.close();
+  }
+});
+
+for (const failure of ["generation", "staging"]) {
+  Deno.test(`aiEmbeddings preserves original data after late ${failure} failure`, async () => {
+    const { sdb, table, assertPreserved } = await createAIEnrichmentFixture();
+    let requests = 0;
+    try {
+      const client = {
+        embeddingEndpoint: "http://failure.local:11434",
+        embed: () => {
+          requests++;
+          if (requests > 1000 && failure === "generation") {
+            throw new Error("late provider failure");
+          }
+          return Promise.resolve({
+            embeddings: [requests > 1000 ? [1, 2, 3] : [1, 2]],
+          });
+        },
+      };
+      await assertRejects(
+        () =>
+          table.aiEmbeddings("text", "existing_vector", {
+            embeddings: {
+              provider: "ollama",
+              model: "lossless-test",
+              ollama: client,
+              cache: false,
+            },
+          }).run(),
+        Error,
+        failure === "generation" ? "late provider failure" : "changed type",
+      );
+      assertEquals(requests > 1000, true);
+      await assertPreserved();
+    } finally {
+      await sdb.close();
+    }
+  });
 }

--- a/test/unit/methods/aiRowByRow.test.ts
+++ b/test/unit/methods/aiRowByRow.test.ts
@@ -1,3 +1,4 @@
+import createAIEnrichmentFixture from "../helpers/createAIEnrichmentFixture.ts";
 import { assert, assertEquals, assertRejects } from "@std/assert";
 import { existsSync, rmSync } from "node:fs";
 import { Ollama } from "ollama";
@@ -515,3 +516,104 @@ Deno.test("aiRowByRow preserves geometry columns", async () => {
     await sdb.close();
   }
 });
+
+Deno.test("aiRowByRow preserves SQL values and queued order across transfer batches", async () => {
+  const { sdb, table, assertPreserved } = await createAIEnrichmentFixture();
+  const sizes: number[] = [];
+  const starts: number[] = [];
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (message: string) => logs.push(message);
+  const client = createOllamaClient((prompt) => {
+    const values = extractValues(prompt);
+    sizes.push(values.length);
+    starts.push(performance.now());
+    return ollamaResponse(
+      values.map((text) => ({ label: text })),
+    );
+  });
+  try {
+    const queued = table.replace("text", { "row-0": "changed" })
+      .aiRowByRow("text", "label", "Copy the text.", {
+        generation: {
+          provider: "ollama",
+          model: "lossless-test",
+          ollama: client,
+          cache: false,
+        },
+        clean: (response) =>
+          (response as { label: string }[]).map((row) => ({
+            ...row,
+            extra: "must not be stored",
+          })),
+        batchSize: 300,
+        concurrency: 2,
+        errorColumn: "error",
+        rateLimitPerMinute: 1200,
+        logProgress: true,
+      })
+      .replace("text", { changed: "row-0" });
+    assertEquals(sizes, []);
+    await queued.run();
+    assertEquals(sizes, [300, 300, 300, 103]);
+    assertEquals(
+      logs,
+      [1, 2, 3, 4].map((n) => `Processed ${n} of 4 requests.`),
+    );
+    for (let i = 1; i < starts.length; i++) {
+      assert(starts[i] - starts[i - 1] >= 40);
+    }
+    await assertPreserved(["label", "error"]);
+    assertEquals(
+      await sdb.customQuery(
+        `SELECT count(*) AS valid FROM enriched
+      WHERE label = CASE WHEN i = 0 THEN 'changed' ELSE text END AND error IS NULL`,
+        { returnData: true },
+      ),
+      [{ valid: 1003 }],
+    );
+  } finally {
+    console.log = originalLog;
+    await sdb.close();
+  }
+});
+
+for (const failure of ["generation", "staging"]) {
+  Deno.test(`aiRowByRow preserves original data after late ${failure} failure`, async () => {
+    const { sdb, table, assertPreserved } = await createAIEnrichmentFixture();
+    let requests = 0;
+    const client = createOllamaClient((prompt) => {
+      requests++;
+      if (requests > 2 && failure === "generation") {
+        throw new Error("late provider failure");
+      }
+      return ollamaResponse(
+        extractValues(prompt).map(() => ({ text: "generated" })),
+      );
+    });
+    try {
+      await assertRejects(
+        () =>
+          table.aiRowByRow("text", "text", "Replace the text.", {
+            generation: {
+              provider: "ollama",
+              model: "lossless-test",
+              ollama: client,
+              cache: false,
+            },
+            batchSize: 500,
+            clean: (response) =>
+              requests > 2 && failure === "staging"
+                ? (response as unknown[]).map(() => ({ text: 42 }))
+                : response,
+          }).run(),
+        Error,
+        failure === "generation" ? "late provider failure" : "changed type",
+      );
+      assertEquals(requests, 3);
+      await assertPreserved();
+    } finally {
+      await sdb.close();
+    }
+  });
+}


### PR DESCRIPTION
## Changes

AI enrichment previously transferred and rebuilt entire rows through JavaScript even when only one input column was needed. Migrate `aiEmbeddings()` and `aiRowByRow()` to core’s `updateColumnsWithJS()` helper so unrelated SQL values and types remain in DuckDB.

Generated columns are staged in bounded batches before replacing the table. Embedding regeneration supports changed dimensions without a temporary output column. Queue order, request pacing, and progress reporting are preserved across transfer batches.

Add integration coverage for independent embedding columns, exact preservation of SQL values and types, queue order, and late generation/staging failures. Update JSDoc and regenerate documentation.

Closes #1246.

## Validation

- 154 tests passed with the published core 2.0.6 dependency and no local import overrides.
- Formatting, lint, type checking, and publishing dry run passed.
- Node and Bun ESM/CommonJS smoke tests and npm pack check passed.
- Documentation lint completed with dependency-resolution warnings; live credential-dependent tests were not exercised.
