### PR TITLE
Add hybrid search FTS table-name regression coverage

### DIFF
--- a/test/unit/methods/hybridSearch.test.ts
+++ b/test/unit/methods/hybridSearch.test.ts
@@ -26,6 +26,41 @@ function clearEmbeddingCaches(): void {
   }
 }
 
+for (const name of ["ranking_probe", "ranking$probe", "Ranking_Épreuve"]) {
+  for (const vectorSearch of [false, true]) {
+    Deno.test(`hybridSearch preserves FTS table name ${name} (vectorSearch=${vectorSearch})`, async () => {
+      const sdb = new SimpleDB();
+      try {
+        const table = sdb.newTable(name);
+        await table.loadArray([
+          { id: "a", text: "zebra" },
+          { id: "b", text: "other" },
+        ]).run();
+
+        const result = table.hybridSearch("zebra", "id", "text", 1, {
+          bm25: true,
+          vectorSearch,
+          outputTable: "result",
+          embeddings: {
+            provider: "ollama",
+            model: "fts-table-name-test",
+            cache: false,
+            ollama: new FakeOllamaEmbeddingClient(
+              "http://fts.local:11434",
+              [1, 0],
+            ),
+          },
+        });
+
+        const rows = await result.getData();
+        assertEquals(rows.map((row) => row.id), ["a"]);
+      } finally {
+        await sdb.close();
+      }
+    });
+  }
+}
+
 Deno.test("hybridSearch preserves geometry columns with table caching", async () => {
   const directory = await Deno.makeTempDir();
   const originalDirectory = Deno.cwd();


### PR DESCRIPTION
Adds the six regression cases requested in #1247 for `ranking_probe`, `ranking$probe`, and `Ranking_Épreuve`, each with BM25 enabled and vector search disabled/enabled. Each case verifies that searching for `zebra` returns only ID `a` in the output table.

SDA already uses core 2.0.6, which contains the FTS schema lookup fix. The tests use the existing fake Ollama embedding client, an explicit model, and disabled caching; they run outside credential-gated blocks and close each database in `finally`.

Validation: `deno fmt`, `deno lint`, and `deno check` passed without warnings. `deno test -A --fail-fast test/unit/methods/hybridSearch.test.ts` passed all 27 registered tests, including the six new cases; credential-gated tests were skipped. An additional `deno doc --lint src/index.ts` check exited successfully but emitted dependency type-resolution warnings.

Closes #1247.
