### PR TITLE
Cover geometry preservation across AI update paths

### DIFF
--- a/test/unit/helpers/createAIEnrichmentFixture.ts
+++ b/test/unit/helpers/createAIEnrichmentFixture.ts
@@ -1,24 +1,61 @@
 import { assertEquals } from "@std/assert";
+import type SimpleTable from "../../../src/class/SimpleTable.ts";
+import { quoteIdentifier } from "@nshiab/simple-data-analysis-core/helpers";
 import SimpleDB from "../../../src/class/SimpleDB.ts";
 
 /** Builds SQL-native values and compares them in DuckDB without JS conversion. */
-export default async function createAIEnrichmentFixture() {
+export default async function createAIEnrichmentFixture(rowCount = 1003) {
   const sdb = new SimpleDB();
   const table = sdb.newTable("enriched");
-  await sdb.customQuery(`CREATE TABLE enriched AS SELECT
+  // Typed ingestion initializes the spatial extension before SQL-native fixtures.
+  await table.loadArray([{ geometry: null }], {
+    columnTypes: { geometry: "GEOMETRY('EPSG:4326')" },
+  }).run();
+  await sdb.customQuery(`CREATE OR REPLACE TABLE enriched AS SELECT
     i, 'row-' || i AS text, 7 AS rowid,
     9007199254740993::BIGINT AS exact,
     DATE '2025-01-01' AS date,
     1234567890123456.789::DECIMAL(19,3) AS amount,
     TIMESTAMP_NS '2025-01-01 12:34:56.123456789' AS instant,
     {'ids': [9007199254740993::BIGINT], 'values': [NULL, 1.234::DECIMAL(7,3)]} AS nested,
-    [1, 2]::FLOAT[2] AS existing_vector
-    FROM range(1003) t(i)`);
+    [1, 2]::FLOAT[2] AS existing_vector,
+    CASE WHEN i % 2 = 0 THEN
+      ST_Point(2.123456789012345, 48.987654321098765)
+      ELSE NULL END::GEOMETRY('EPSG:4326') AS geometry,
+    ST_Point(1234567.8901234567, 7654321.098765432)::GEOMETRY('EPSG:3857') AS projected,
+    ST_Point(1.123456789012345, 2.987654321098765) AS unknown_crs,
+    NULL::GEOMETRY('EPSG:4326') AS null_geometry
+    FROM range(${rowCount}) t(i)`);
   await sdb.customQuery("CREATE TABLE expected AS SELECT * FROM enriched");
   const originalTypes = await table.getTypes();
   return {
     sdb,
     table,
+    assertGeometry: async (result: SimpleTable = table) => {
+      const types = await result.getTypes();
+      const geometryColumns = Object.keys(originalTypes).filter((name) =>
+        originalTypes[name].startsWith("GEOMETRY")
+      );
+      for (const name of geometryColumns) {
+        assertEquals(types[name], originalTypes[name]);
+      }
+      const projection = [
+        "i",
+        ...geometryColumns.map((name) =>
+          `ST_AsWKB(${quoteIdentifier(name)}) AS ${quoteIdentifier(name)}`
+        ),
+      ].join(", ");
+      assertEquals(
+        await sdb.customQuery(
+          `SELECT count(*) AS differences FROM (
+          (SELECT ${projection} FROM ${quoteIdentifier(result.name)})
+          EXCEPT ALL (SELECT ${projection} FROM expected)
+        )`,
+          { returnData: true },
+        ),
+        [{ differences: 0 }],
+      );
+    },
     assertPreserved: async (outputs: string[] = []) => {
       const types = await table.getTypes();
       assertEquals(
@@ -27,14 +64,18 @@ export default async function createAIEnrichmentFixture() {
         ),
         originalTypes,
       );
-      const projection = Object.keys(originalTypes).map((name) => `"${name}"`)
+      const projection = Object.keys(originalTypes).map((name) =>
+        originalTypes[name].startsWith("GEOMETRY")
+          ? `ST_AsWKB("${name}") AS "${name}"`
+          : `"${name}"`
+      )
         .join(", ");
       assertEquals(
         await sdb.customQuery(
           `SELECT count(*) AS differences FROM (
-        ((SELECT ${projection} FROM enriched) EXCEPT ALL (SELECT * FROM expected))
+        ((SELECT ${projection} FROM enriched) EXCEPT ALL (SELECT ${projection} FROM expected))
         UNION ALL
-        ((SELECT * FROM expected) EXCEPT ALL (SELECT ${projection} FROM enriched))
+        ((SELECT ${projection} FROM expected) EXCEPT ALL (SELECT ${projection} FROM enriched))
       )`,
           { returnData: true },
         ),

--- a/test/unit/methods/aiEmbeddings.test.ts
+++ b/test/unit/methods/aiEmbeddings.test.ts
@@ -919,3 +919,36 @@ for (const failure of ["generation", "staging"]) {
     }
   });
 }
+
+for (const target of ["input", "output"] as const) {
+  Deno.test(`aiEmbeddings rejects geometry ${target} before provider requests`, async () => {
+    const { sdb, table, assertPreserved } = await createAIEnrichmentFixture(2);
+    const client = new FakeOllamaEmbeddingClient(
+      "http://geometry.local:11434",
+      [1, 0],
+    );
+    try {
+      await assertRejects(
+        () =>
+          table.aiEmbeddings(
+            target === "input" ? "UNKNOWN_CRS" : "text",
+            target === "output" ? "PROJECTED" : "vectors",
+            {
+              embeddings: {
+                provider: "ollama",
+                model: "geometry-test",
+                ollama: client,
+                cache: false,
+              },
+            },
+          ).run(),
+        Error,
+        "cannot be an input or output",
+      );
+      assertEquals(client.requests, 0);
+      await assertPreserved();
+    } finally {
+      await sdb.close();
+    }
+  });
+}

--- a/test/unit/methods/aiRAG.test.ts
+++ b/test/unit/methods/aiRAG.test.ts
@@ -1,4 +1,5 @@
-import { assertEquals } from "@std/assert";
+import createAIEnrichmentFixture from "../helpers/createAIEnrichmentFixture.ts";
+import { assertEquals, assertRejects } from "@std/assert";
 import SimpleDB from "../../../src/class/SimpleDB.ts";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import createEnvironmentTest from "../helpers/createEnvironmentTest.ts";
@@ -918,3 +919,129 @@ if (hasOllama) {
     "Neither AI_PROVIDER nor AI_EMBEDDINGS_PROVIDER is set to ollama",
   );
 }
+
+for (
+  const mode of ["disabled", "reused", "generated", "regenerated"] as const
+) {
+  Deno.test(
+    "aiRAG preserves exact geometry across CRS with vector search " + mode,
+    async () => {
+      const { sdb, table, assertGeometry, assertPreserved } =
+        await createAIEnrichmentFixture(12);
+      const client = new FakeOllamaEmbeddingClient(
+        "http://geometry.local:11434",
+        [1, 0],
+      );
+      const embeddings = {
+        provider: "ollama",
+        model: "geometry-search",
+        ollama: client,
+        cache: false,
+      } as const;
+      try {
+        if (mode === "reused" || mode === "regenerated") {
+          await table.aiEmbeddings("text", "text_embeddings", {
+            embeddings: {
+              ...embeddings,
+              model: mode === "reused" ? embeddings.model : "old-model",
+            },
+          }).run();
+        }
+        const before = client.requests;
+
+        const generationClient = new Ollama({
+          host: "http://unused.local:11434",
+        });
+        let generations = 0;
+        Object.defineProperty(generationClient, "chat", {
+          value: () => {
+            generations++;
+            return Promise.resolve({
+              message: { role: "assistant", content: "answer" },
+              prompt_eval_count: 1,
+              eval_count: 1,
+            });
+          },
+        });
+        const generation = {
+          provider: "ollama",
+          model: "fake-generation",
+          ollama: generationClient,
+          cache: false,
+        } as const;
+
+        assertEquals(
+          await table.aiRAG("row", "i", "text", 3, {
+            embeddings,
+            generation,
+            vectorSearch: mode !== "disabled",
+          }),
+          "answer",
+        );
+        assertEquals(generations, 1);
+
+        assertEquals(
+          client.requests - before,
+          mode === "disabled" ? 0 : mode === "reused" ? 1 : 13,
+        );
+        await assertGeometry();
+        await assertPreserved(mode === "disabled" ? [] : ["text_embeddings"]);
+      } finally {
+        await sdb.close();
+      }
+    },
+  );
+}
+
+Deno.test("aiRAG rejects a geometry embedding-column collision before provider requests", async () => {
+  const { sdb, table, assertPreserved } = await createAIEnrichmentFixture(2);
+  const client = new FakeOllamaEmbeddingClient("http://geometry.local:11434", [
+    1,
+    0,
+  ]);
+  const embeddings = {
+    provider: "ollama",
+    model: "geometry-search",
+    ollama: client,
+    cache: false,
+  } as const;
+  try {
+    await sdb.customQuery(
+      "ALTER TABLE enriched ADD COLUMN text_embeddings GEOMETRY('EPSG:3857')",
+    );
+
+    const generationClient = new Ollama({ host: "http://unused.local:11434" });
+    let generations = 0;
+    Object.defineProperty(generationClient, "chat", {
+      value: () => {
+        generations++;
+        return Promise.resolve({
+          message: { role: "assistant", content: "answer" },
+          prompt_eval_count: 1,
+          eval_count: 1,
+        });
+      },
+    });
+    const generation = {
+      provider: "ollama",
+      model: "fake-generation",
+      ollama: generationClient,
+      cache: false,
+    } as const;
+
+    await assertRejects(
+      () => table.aiRAG("row", "i", "text", 3, { embeddings, generation }),
+      Error,
+      "cannot be an input or output",
+    );
+    assertEquals(client.requests, 0);
+    assertEquals(generations, 0);
+    assertEquals(
+      (await table.getTypes()).text_embeddings,
+      "GEOMETRY('EPSG:3857')",
+    );
+    await assertPreserved(["text_embeddings"]);
+  } finally {
+    await sdb.close();
+  }
+});

--- a/test/unit/methods/aiRowByRow.test.ts
+++ b/test/unit/methods/aiRowByRow.test.ts
@@ -617,3 +617,72 @@ for (const failure of ["generation", "staging"]) {
     }
   });
 }
+
+for (const target of ["input", "output", "errorColumn"] as const) {
+  Deno.test(`aiRowByRow rejects geometry ${target} before provider requests`, async () => {
+    const { sdb, table, assertPreserved } = await createAIEnrichmentFixture(2);
+    const fixture = createOllamaFixture();
+    try {
+      await assertRejects(
+        () =>
+          table.aiRowByRow(
+            target === "input" ? "GEOMETRY" : "text",
+            target === "output" ? "PROJECTED" : "label",
+            "Label the input.",
+            {
+              generation: { ...fixture.generation, cache: false },
+              errorColumn: target === "errorColumn"
+                ? "NULL_GEOMETRY"
+                : undefined,
+            },
+          ).run(),
+        Error,
+        "cannot be an input or output",
+      );
+      assertEquals(fixture.requestCount(), 0);
+      await assertPreserved();
+    } finally {
+      await sdb.close();
+    }
+  });
+}
+
+Deno.test("aiRowByRow logs compact geometry separately from stored SQL values", async () => {
+  const { sdb, table, assertGeometry } = await createAIEnrichmentFixture(2);
+  const client = createOllamaClient((prompt) =>
+    ollamaResponse(
+      extractValues(prompt).map(() => ({ label: "place" })),
+    )
+  );
+  const logs: string[] = [];
+  const originalLog = console.log;
+  try {
+    await table.aiRowByRow("text", "label", "Label the input.", {
+      generation: {
+        provider: "ollama",
+        model: "geometry-log",
+        ollama: client,
+        cache: false,
+      },
+    }).run();
+    console.log = (...values: unknown[]) =>
+      logs.push(values.map(String).join(" "));
+    await table.selectColumns([
+      "i",
+      "label",
+      "geometry",
+      "projected",
+      "unknown_crs",
+      "null_geometry",
+    ]).log({ count: 2, types: false });
+    const output = logs.join("\n");
+    assert(output.includes("GEOM(EPSG:4326)"));
+    assert(output.includes("GEOM(EPSG:3857)"));
+    assert(!output.includes("2.123456789012345"));
+    assert(!output.includes("coordinates"));
+    await assertGeometry();
+  } finally {
+    console.log = originalLog;
+    await sdb.close();
+  }
+});

--- a/test/unit/methods/hybridSearch.test.ts
+++ b/test/unit/methods/hybridSearch.test.ts
@@ -1,3 +1,4 @@
+import createAIEnrichmentFixture from "../helpers/createAIEnrichmentFixture.ts";
 import { assertEquals, assertRejects } from "@std/assert";
 import SimpleDB from "../../../src/class/SimpleDB.ts";
 import { existsSync, rmSync } from "node:fs";
@@ -1170,5 +1171,91 @@ Deno.test("hybridSearch rejects score column collisions", async () => {
     } finally {
       await sdb.close();
     }
+  }
+});
+
+for (
+  const mode of ["disabled", "reused", "generated", "regenerated"] as const
+) {
+  Deno.test(
+    "hybridSearch preserves exact geometry across CRS with vector search " +
+      mode,
+    async () => {
+      const { sdb, table, assertGeometry, assertPreserved } =
+        await createAIEnrichmentFixture(12);
+      const client = new FakeOllamaEmbeddingClient(
+        "http://geometry.local:11434",
+        [1, 0],
+      );
+      const embeddings = {
+        provider: "ollama",
+        model: "geometry-search",
+        ollama: client,
+        cache: false,
+      } as const;
+      try {
+        if (mode === "reused" || mode === "regenerated") {
+          await table.aiEmbeddings("text", "text_embeddings", {
+            embeddings: {
+              ...embeddings,
+              model: mode === "reused" ? embeddings.model : "old-model",
+            },
+          }).run();
+        }
+        const before = client.requests;
+
+        const result = table.hybridSearch("row", "i", "text", 3, {
+          embeddings,
+          vectorSearch: mode !== "disabled",
+          outputTable: "geometry_results",
+        });
+        await result.run();
+        assertEquals(await result.getRowCount() > 0, true);
+        await assertGeometry(result);
+
+        assertEquals(
+          client.requests - before,
+          mode === "disabled" ? 0 : mode === "reused" ? 1 : 13,
+        );
+        await assertGeometry();
+        await assertPreserved(mode === "disabled" ? [] : ["text_embeddings"]);
+      } finally {
+        await sdb.close();
+      }
+    },
+  );
+}
+
+Deno.test("hybridSearch rejects a geometry embedding-column collision before provider requests", async () => {
+  const { sdb, table, assertPreserved } = await createAIEnrichmentFixture(2);
+  const client = new FakeOllamaEmbeddingClient("http://geometry.local:11434", [
+    1,
+    0,
+  ]);
+  const embeddings = {
+    provider: "ollama",
+    model: "geometry-search",
+    ollama: client,
+    cache: false,
+  } as const;
+  try {
+    await sdb.customQuery(
+      "ALTER TABLE enriched ADD COLUMN text_embeddings GEOMETRY('EPSG:3857')",
+    );
+
+    await assertRejects(
+      () => table.hybridSearch("row", "i", "text", 3, { embeddings }).run(),
+      Error,
+      "cannot be an input or output",
+    );
+    assertEquals(client.requests, 0);
+
+    assertEquals(
+      (await table.getTypes()).text_embeddings,
+      "GEOMETRY('EPSG:3857')",
+    );
+    await assertPreserved(["text_embeddings"]);
+  } finally {
+    await sdb.close();
   }
 });


### PR DESCRIPTION
Closes #1250.

AI enrichment and search should preserve unrelated geometry columns just like other untouched SQL values. Add regression coverage for exact geometry values, null/all-null and multiple geometry columns, and known, projected, and unknown CRS across enrichment, embedding refresh, and search/RAG paths.

The tests also verify case-insensitive geometry input/output collisions fail before provider requests, late generation/staging failures preserve the original data, and compact log output does not substitute for stored-value assertions. This PR changes only tests; the existing public documentation remains unchanged.

Validation: all 81 tests in the four affected method suites pass with fake providers and no credentials. Formatting, lint, type checking, and the publish dry run pass. Documentation lint exits successfully with the same 82 dependency-resolution warnings reproduced on unmodified main.
